### PR TITLE
Fix time in error page

### DIFF
--- a/src/HE.InvestmentLoans.BusinessLogic/LoanApplication/Entities/LoanApplicationEntity.cs
+++ b/src/HE.InvestmentLoans.BusinessLogic/LoanApplication/Entities/LoanApplicationEntity.cs
@@ -13,12 +13,14 @@ namespace HE.InvestmentLoans.BusinessLogic.LoanApplication.Entities;
 
 public class LoanApplicationEntity
 {
-    public LoanApplicationEntity(LoanApplicationId id, UserAccount userAccount, ApplicationStatus externalStatus)
+    public LoanApplicationEntity(LoanApplicationId id, UserAccount userAccount, ApplicationStatus externalStatus, DateTime? lastModificationDate)
     {
         Id = id;
         UserAccount = userAccount;
         ApplicationProjects = new ApplicationProjects(Id);
         ExternalStatus = externalStatus;
+
+        LastModificationDate = lastModificationDate;
     }
 
     public LoanApplicationId Id { get; private set; }
@@ -31,7 +33,9 @@ public class LoanApplicationEntity
 
     public ApplicationStatus ExternalStatus { get; set; }
 
-    public static LoanApplicationEntity New(UserAccount userAccount) => new(LoanApplicationId.New(), userAccount, ApplicationStatus.Draft);
+    public DateTime? LastModificationDate { get; private set; }
+
+    public static LoanApplicationEntity New(UserAccount userAccount) => new(LoanApplicationId.New(), userAccount, ApplicationStatus.Draft, null);
 
     public void SaveApplicationProjects(ApplicationProjects applicationProjects)
     {
@@ -61,8 +65,7 @@ public class LoanApplicationEntity
             throw new DomainException(
                 "Loan application has been submitted",
                 CommonErrorCodes.ApplicationHasBeenSubmitted,
-                ("Date", LegacyModel.Timestamp.Date.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)),
-                ("Hour", LegacyModel.Timestamp.Date.ToString("hh:mm tt", CultureInfo.InvariantCulture)));
+                ("Date", LastModificationDate!.Value));
         }
 
         await canSubmitLoanApplication.Submit(Id, cancellationToken);

--- a/src/HE.InvestmentLoans.BusinessLogic/LoanApplication/Repositories/LoanApplicationRepository.cs
+++ b/src/HE.InvestmentLoans.BusinessLogic/LoanApplication/Repositories/LoanApplicationRepository.cs
@@ -47,7 +47,7 @@ public class LoanApplicationRepository : ILoanApplicationRepository, ICanSubmitL
 
         var externalStatus = ApplicationStatusMapper.MapToPortalStatus(loanApplicationDto.loanApplicationExternalStatus);
 
-        return new LoanApplicationEntity(id, userAccount, externalStatus)
+        return new LoanApplicationEntity(id, userAccount, externalStatus, loanApplicationDto.LastModificationOn)
         {
             LegacyModel = LoanApplicationMapper.Map(loanApplicationDto),
         };

--- a/src/HE.InvestmentLoans.Common/Extensions/DateTimeExtensions.cs
+++ b/src/HE.InvestmentLoans.Common/Extensions/DateTimeExtensions.cs
@@ -5,4 +5,11 @@ public static class DateTimeExtensions
     public static bool IsBeforeOrEqualTo(this DateTime date, DateTime otherDate) => date <= otherDate;
 
     public static bool IsAfter(this DateTime date, DateTime otherDate) => date > otherDate;
+
+    public static DateTime ConvertUtcToUkLocalTime(this DateTime utcDate)
+    {
+        var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+
+        return timeZoneInfo.IsDaylightSavingTime(utcDate) ? utcDate.AddHours(1) : utcDate;
+    }
 }

--- a/src/HE.InvestmentLoans.Common/Models/Others/ErrorModel.cs
+++ b/src/HE.InvestmentLoans.Common/Models/Others/ErrorModel.cs
@@ -17,7 +17,7 @@ public class ErrorModel
         ErrorCode = errorCode;
     }
 
-    public ErrorModel(string message, string errorCode, Dictionary<string, string> additionalData)
+    public ErrorModel(string message, string errorCode, Dictionary<string, object> additionalData)
     {
         Message = message;
         ErrorCode = errorCode;
@@ -32,5 +32,5 @@ public class ErrorModel
 
     public string ErrorCode { get; set; }
 
-    public Dictionary<string, string> AdditionalData { get; set; }
+    public Dictionary<string, object> AdditionalData { get; set; }
 }

--- a/src/HE.InvestmentLoans.Contract/Exceptions/DomainException.cs
+++ b/src/HE.InvestmentLoans.Contract/Exceptions/DomainException.cs
@@ -6,14 +6,15 @@ public class DomainException : Exception
         : base(message, innerException)
     {
         ErrorCode = errorCode;
+        AdditionalData = new Dictionary<string, object>();
     }
 
-    public DomainException(string message, string errorCode, params (string Key, string Value)[] additionalData)
+    public DomainException(string message, string errorCode, params (string Key, object Value)[] additionalData)
         : base(message)
     {
         ErrorCode = errorCode;
 
-        AdditionalData = new Dictionary<string, string>();
+        AdditionalData = new Dictionary<string, object>();
 
         foreach (var (key, value) in additionalData)
         {
@@ -23,5 +24,5 @@ public class DomainException : Exception
 
     public string ErrorCode { get; }
 
-    public Dictionary<string, string> AdditionalData { get; private set; }
+    public Dictionary<string, object> AdditionalData { get; private set; }
 }

--- a/src/HE.InvestmentLoans.WWW/Utils/Errors/ErrorContentProvider.cs
+++ b/src/HE.InvestmentLoans.WWW/Utils/Errors/ErrorContentProvider.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using HE.InvestmentLoans.Common.Extensions;
 using HE.InvestmentLoans.Common.Models.Others;
 using HE.InvestmentLoans.Contract;
 
@@ -9,8 +11,17 @@ public static class ErrorContentProvider
     {
         return errorModel.ErrorCode switch
         {
-            CommonErrorCodes.ApplicationHasBeenSubmitted => ("This application has already been submitted", $"Application submitted at {errorModel.AdditionalData["Hour"]} on {errorModel.AdditionalData["Date"]}"),
+            CommonErrorCodes.ApplicationHasBeenSubmitted => ApplicationHasBeenSubmittedError(errorModel),
             _ => (null, null),
         };
+    }
+
+    private static (string Header, string Body) ApplicationHasBeenSubmittedError(ErrorModel errorModel)
+    {
+        var utcDate = (DateTime)errorModel.AdditionalData["Date"];
+
+        var ukDate = utcDate.ConvertUtcToUkLocalTime();
+
+        return ("This application has already been submitted", $"Application submitted at {ukDate.ToString("hh:mm tt", CultureInfo.InvariantCulture)} on {ukDate.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)}");
     }
 }


### PR DESCRIPTION
- use modification date saved from CRM to avoid loosing modification date after cache timeout
- pass whole modification date to decouple business logic from concrete display format in error page