### PR TITLE
AB#93585 Downgrade Moq library.

### DIFF
--- a/src/HE.Investment.AHP.Domain.Tests/HE.Investment.AHP.Domain.Tests.csproj
+++ b/src/HE.Investment.AHP.Domain.Tests/HE.Investment.AHP.Domain.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HE.Investment.AHP.WWW.Tests/HE.Investment.AHP.WWW.Tests.csproj
+++ b/src/HE.Investment.AHP.WWW.Tests/HE.Investment.AHP.WWW.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/HE.Investments.Account.Domain.Tests/HE.Investments.Account.Domain.Tests.csproj
+++ b/src/HE.Investments.Account.Domain.Tests/HE.Investments.Account.Domain.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 

--- a/src/HE.Investments.Account.Shared.Tests/HE.Investments.Account.Shared.Tests.csproj
+++ b/src/HE.Investments.Account.Shared.Tests/HE.Investments.Account.Shared.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HE.Investments.Account.WWW.Tests/HE.Investments.Account.WWW.Tests.csproj
+++ b/src/HE.Investments.Account.WWW.Tests/HE.Investments.Account.WWW.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5"/>
-    <PackageReference Include="Moq" Version="4.20.69"/>
+    <PackageReference Include="Moq" Version="4.18.4"/>
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0"/>
   </ItemGroup>
 

--- a/src/HE.Investments.Common.Tests/HE.Investments.Common.Tests.csproj
+++ b/src/HE.Investments.Common.Tests/HE.Investments.Common.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.FeatureManagement" Version="3.0.0" />
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/HE.Investments.Common.WWW.Tests/HE.Investments.Common.WWW.Tests.csproj
+++ b/src/HE.Investments.Common.WWW.Tests/HE.Investments.Common.WWW.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/HE.Investments.Common.WWWTestsFramework/HE.Investments.Common.WWWTestsFramework.csproj
+++ b/src/HE.Investments.Common.WWWTestsFramework/HE.Investments.Common.WWWTestsFramework.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/HE.Investments.FrontDoor.Domain.Tests/HE.Investments.FrontDoor.Domain.Tests.csproj
+++ b/src/HE.Investments.FrontDoor.Domain.Tests/HE.Investments.FrontDoor.Domain.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HE.Investments.Loans.BusinessLogic.Tests/HE.Investments.Loans.BusinessLogic.Tests.csproj
+++ b/src/HE.Investments.Loans.BusinessLogic.Tests/HE.Investments.Loans.BusinessLogic.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/HE.Investments.Loans.Common.Tests/HE.Investments.Loans.Common.Tests.csproj
+++ b/src/HE.Investments.Loans.Common.Tests/HE.Investments.Loans.Common.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/HE.Investments.Loans.Contract.Tests/HE.Investments.Loans.Contract.Tests.csproj
+++ b/src/HE.Investments.Loans.Contract.Tests/HE.Investments.Loans.Contract.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.5.3" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/HE.Investments.Loans.WWW.Tests/HE.Investments.Loans.WWW.Tests.csproj
+++ b/src/HE.Investments.Loans.WWW.Tests/HE.Investments.Loans.WWW.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Razor.Templating.Core" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/HE.Investments.Organisation.Tests/HE.Investments.Organisation.Tests.csproj
+++ b/src/HE.Investments.Organisation.Tests/HE.Investments.Organisation.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HE.Investments.TestsUtils/HE.Investments.TestsUtils.csproj
+++ b/src/HE.Investments.TestsUtils/HE.Investments.TestsUtils.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### 🛠 Changes being made

Downgrade Moq library to 4.18.4 because of [security vulnerability](https://medium.com/@michalsitek/critical-security-vulnerability-in-moq-4-20-0-ffd24739cc49)
