### PR TITLE
AB#94049 AHP - change workflow for Sites MMC section when it is enabled for some home types

### DIFF
--- a/src/HE.Investment.AHP.Domain.Tests/HomeTypes/EntitiesTests/TenureDetailsSegmentEntityTests/ChangeExemptFromTheRightToSharedOwnershipTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/HomeTypes/EntitiesTests/TenureDetailsSegmentEntityTests/ChangeExemptFromTheRightToSharedOwnershipTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using HE.Investment.AHP.Domain.HomeTypes.ValueObjects;
+using HE.Investment.AHP.Domain.Tests.HomeTypes.TestDataBuilders;
+using HE.Investments.Common.Contract.Enum;
+
+namespace HE.Investment.AHP.Domain.Tests.HomeTypes.EntitiesTests.TenureDetailsSegmentEntityTests;
+
+public class ChangeExemptFromTheRightToSharedOwnershipTests
+{
+    [Theory]
+    [InlineData(YesNoType.No)]
+    [InlineData(YesNoType.Undefined)]
+    public void ShouldClearExemptJustification_WhenAnswerIs(YesNoType answer)
+    {
+        // given
+        var testCandidate = new TenureDetailsTestDataBuilder()
+            .WithExemptFromTheRightToSharedOwnership(YesNoType.Yes)
+            .WithExemptionJustification("some justification")
+            .Build();
+
+        // when
+        testCandidate.ChangeExemptFromTheRightToSharedOwnership(answer);
+
+        // then
+        testCandidate.IsModified.Should().BeTrue();
+        testCandidate.ExemptionJustification.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShouldNotClearExemptJustification_WhenAnswerIsAlreadyYes()
+    {
+        // given
+        var testCandidate = new TenureDetailsTestDataBuilder()
+            .WithExemptFromTheRightToSharedOwnership(YesNoType.Yes)
+            .WithExemptionJustification("some justification")
+            .Build();
+
+        // when
+        testCandidate.ChangeExemptFromTheRightToSharedOwnership(YesNoType.Yes);
+
+        // then
+        testCandidate.IsModified.Should().BeFalse();
+        testCandidate.ExemptionJustification.Should().Be(new MoreInformation("some justification"));
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Site/Entities/SiteEntityTests/CompleteTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/Entities/SiteEntityTests/CompleteTests.cs
@@ -3,6 +3,7 @@ using HE.Investment.AHP.Contract.Common.Enums;
 using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Contract.Site.Enums;
 using HE.Investment.AHP.Domain.Site.ValueObjects;
+using HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 using HE.Investment.AHP.Domain.Site.ValueObjects.Planning;
 using HE.Investment.AHP.Domain.Site.ValueObjects.Planning.PlanningDetailsTypes;
 using HE.Investment.AHP.Domain.Tests.Site.TestDataBuilders;
@@ -85,7 +86,10 @@ public class CompleteTests
             .WithSiteUseDetails(SiteUseDetailsBuilder.New().WithIsPartOfStreetFrontInfill(true).WithIsForTravellerPitchSite(false).Build())
             .WithRuralClassification(SiteRuralClassificationBuilder.New().WithIsRuralExceptionSite(true).WithIsWithinRuralSettlement(true).Build())
             .WithEnvironmentalImpact(new EnvironmentalImpact("impact"))
-            .WithModernMethodsOfConstruction(SiteModernMethodsOfConstructionBuilder.New().WithIsUsingMmc(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes).Build())
+            .WithModernMethodsOfConstruction(SiteModernMethodsOfConstructionBuilder.New()
+                .WithIsUsingMmc(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes)
+                .WithInformation("some barriers", "some impact")
+                .Build())
             .WithProcurements(SiteProcurementsBuilder.New().WithProcurements(SiteProcurement.PartneringSupplyChain).Build());
     }
 }

--- a/src/HE.Investment.AHP.Domain.Tests/Site/Entities/SiteEntityTests/IsAnsweredTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/Entities/SiteEntityTests/IsAnsweredTests.cs
@@ -247,7 +247,10 @@ public class IsAnsweredTests
             .WithSiteUseDetails(SiteUseDetailsBuilder.New().WithIsPartOfStreetFrontInfill(true).WithIsForTravellerPitchSite(false).Build())
             .WithRuralClassification(SiteRuralClassificationBuilder.New().WithIsRuralExceptionSite(true).WithIsWithinRuralSettlement(true).Build())
             .WithEnvironmentalImpact(new EnvironmentalImpact("impact"))
-            .WithModernMethodsOfConstruction(SiteModernMethodsOfConstructionBuilder.New().WithIsUsingMmc(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes).Build())
+            .WithModernMethodsOfConstruction(SiteModernMethodsOfConstructionBuilder.New()
+                .WithIsUsingMmc(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes)
+                .WithInformation("some barriers", "some impact")
+                .Build())
             .WithProcurements(SiteProcurementsBuilder.New().WithProcurements(SiteProcurement.PartneringSupplyChain).Build());
     }
 }

--- a/src/HE.Investment.AHP.Domain.Tests/Site/TestDataBuilders/SiteModernMethodsOfConstructionBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/TestDataBuilders/SiteModernMethodsOfConstructionBuilder.cs
@@ -1,4 +1,5 @@
 using HE.Investment.AHP.Contract.Site;
+using HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 using HE.Investments.TestsUtils.TestFramework;
 using SiteModernMethodsOfConstruction = HE.Investment.AHP.Domain.Site.ValueObjects.Mmc.SiteModernMethodsOfConstruction;
 
@@ -16,4 +17,8 @@ public class SiteModernMethodsOfConstructionBuilder : TestObjectBuilder<SiteMode
     public static SiteModernMethodsOfConstructionBuilder New() => new();
 
     public SiteModernMethodsOfConstructionBuilder WithIsUsingMmc(SiteUsingModernMethodsOfConstruction value) => SetProperty(x => x.SiteUsingModernMethodsOfConstruction, value);
+
+    public SiteModernMethodsOfConstructionBuilder WithInformation(string barriers, string impact) => SetProperty(
+        x => x.Information,
+        new ModernMethodsOfConstructionInformation(new ModernMethodsOfConstructionBarriers(barriers), new ModernMethodsOfConstructionImpact(impact)));
 }

--- a/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/Mmc/SiteModernMethodsOfConstructionTests/IsAnsweredTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/Mmc/SiteModernMethodsOfConstructionTests/IsAnsweredTests.cs
@@ -60,12 +60,14 @@ public class IsAnsweredTests
         result.Should().BeTrue();
     }
 
-    [Fact]
-    public void ShouldReturnFalse_WhenSiteUsingModernMethodsOfConstructionInformationNotProvided()
+    [Theory]
+    [InlineData(SiteUsingModernMethodsOfConstruction.Yes)]
+    [InlineData(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes)]
+    public void ShouldReturnFalse_WhenSiteUsingModernMethodsOfConstructionInformationNotProvided(SiteUsingModernMethodsOfConstruction usingMmc)
     {
         // given
         var details = new SiteModernMethodsOfConstruction(
-            SiteUsingModernMethodsOfConstruction.Yes,
+            usingMmc,
             null,
             null,
             _modernMethodsOfConstruction);
@@ -93,10 +95,12 @@ public class IsAnsweredTests
     }
 
     [Fact]
-    public void ShouldReturnTrue_WhenSiteUsingModernMethodsOfConstructionOnlyForSomeHomes()
+    public void ShouldReturnTrue_WhenAllDataProvidedForSiteUsingModernMethodsOfConstructionOnlyForSomeHomes()
     {
         // given
-        var details = new SiteModernMethodsOfConstruction(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes);
+        var details = new SiteModernMethodsOfConstruction(
+            SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes,
+            new ModernMethodsOfConstructionInformation(_modernMethodsOfConstructionBarriers, _modernMethodsOfConstructionImpact));
 
         // when
         var result = details.IsAnswered();

--- a/src/HE.Investment.AHP.Domain/HomeTypes/Entities/TenureDetailsSegmentEntity.cs
+++ b/src/HE.Investment.AHP.Domain/HomeTypes/Entities/TenureDetailsSegmentEntity.cs
@@ -103,7 +103,10 @@ public class TenureDetailsSegmentEntity : IHomeTypeSegmentEntity
 
     public void ChangeExemptFromTheRightToSharedOwnership(YesNoType exemptFromTheRightToSharedOwnership)
     {
-        ExemptFromTheRightToSharedOwnership = _modificationTracker.Change(ExemptFromTheRightToSharedOwnership, exemptFromTheRightToSharedOwnership);
+        ExemptFromTheRightToSharedOwnership = _modificationTracker.Change(
+            ExemptFromTheRightToSharedOwnership,
+            exemptFromTheRightToSharedOwnership,
+            onChangedWithParamList: ClearExemptJustification);
     }
 
     public void ChangeExemptionJustification(MoreInformation? newValue)
@@ -223,6 +226,14 @@ public class TenureDetailsSegmentEntity : IHomeTypeSegmentEntity
         ExpectedFirstTranche = null;
         ProspectiveRentAsPercentageOfMarketRent = null;
         RentAsPercentageOfTheUnsoldShare = null;
+    }
+
+    private void ClearExemptJustification(YesNoType exemptFromTheRightToSharedOwnership)
+    {
+        if (exemptFromTheRightToSharedOwnership != YesNoType.Yes)
+        {
+            ChangeExemptionJustification(null);
+        }
     }
 
     private bool IsExemptJustificationProvided()

--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/SiteModernMethodsOfConstruction.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/SiteModernMethodsOfConstruction.cs
@@ -35,7 +35,7 @@ public class SiteModernMethodsOfConstruction : ValueObject, IQuestion
 
         if (siteUsingModernMethodsOfConstruction == Contract.Site.SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes)
         {
-            return new SiteModernMethodsOfConstruction(siteUsingModernMethodsOfConstruction);
+            return new SiteModernMethodsOfConstruction(siteUsingModernMethodsOfConstruction, old.Information);
         }
 
         if (siteUsingModernMethodsOfConstruction == Contract.Site.SiteUsingModernMethodsOfConstruction.Yes)
@@ -105,7 +105,7 @@ public class SiteModernMethodsOfConstruction : ValueObject, IQuestion
 
         if (SiteUsingModernMethodsOfConstruction is Contract.Site.SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes)
         {
-            return true;
+            return Information != null && Information.IsAnswered();
         }
 
         return false;

--- a/src/HE.Investment.AHP.WWW.Tests/Workflows/SiteWorkflowTests/Mmc/NextStateTests.cs
+++ b/src/HE.Investment.AHP.WWW.Tests/Workflows/SiteWorkflowTests/Mmc/NextStateTests.cs
@@ -11,7 +11,6 @@ public class NextStateTests
     [InlineData(SiteWorkflowState.EnvironmentalImpact, SiteWorkflowState.MmcUsing)]
     [InlineData(SiteWorkflowState.MmcUsing, SiteWorkflowState.Procurements)]
     [InlineData(SiteWorkflowState.MmcFutureAdoption, SiteWorkflowState.Procurements)]
-    [InlineData(SiteWorkflowState.MmcInformation, SiteWorkflowState.MmcCategories)]
     [InlineData(SiteWorkflowState.MmcCategories, SiteWorkflowState.Procurements)]
     [InlineData(SiteWorkflowState.Mmc3DCategory, SiteWorkflowState.Procurements)]
     [InlineData(SiteWorkflowState.Mmc2DCategory, SiteWorkflowState.Procurements)]
@@ -42,7 +41,7 @@ public class NextStateTests
 
     [Theory]
     [InlineData(SiteUsingModernMethodsOfConstruction.Yes, SiteWorkflowState.MmcInformation)]
-    [InlineData(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes, SiteWorkflowState.Procurements)]
+    [InlineData(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes, SiteWorkflowState.MmcInformation)]
     public async Task ShouldReturnNextState_WhenContinueTriggerExecutedWithModernMethodsOfConstruction(
         SiteUsingModernMethodsOfConstruction usingModernMethodsOfConstruction,
         SiteWorkflowState expectedState)
@@ -162,11 +161,11 @@ public class NextStateTests
     }
 
     [Fact]
-    public async Task ShouldReturnMmcUsing_WhenBackTriggerExecutedForOnlyForSomeHomesModernMethodsOfConstruction()
+    public async Task ShouldReturnMmcInformation_WhenBackTriggerExecutedForOnlyForSomeHomesModernMethodsOfConstruction()
     {
         var modernMethodsOfConstruction = new SiteModernMethodsOfConstruction(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes);
 
-        await TestBack(SiteWorkflowState.Procurements, SiteWorkflowState.MmcUsing, modernMethodsOfConstruction);
+        await TestBack(SiteWorkflowState.Procurements, SiteWorkflowState.MmcInformation, modernMethodsOfConstruction);
     }
 
     private static async Task TestBack(

--- a/src/HE.Investment.AHP.WWW.Tests/Workflows/SiteWorkflowTests/StateCanBeAccessedTests.cs
+++ b/src/HE.Investment.AHP.WWW.Tests/Workflows/SiteWorkflowTests/StateCanBeAccessedTests.cs
@@ -117,7 +117,8 @@ public class StateCanBeAccessedTests
 
     [Theory]
     [InlineData(SiteUsingModernMethodsOfConstruction.Yes, true)]
-    [InlineData(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes, false)]
+    [InlineData(SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes, true)]
+    [InlineData(SiteUsingModernMethodsOfConstruction.No, false)]
     public async Task ShouldReturnTrue_WhenMethodCalledForMmcInformationForSomeSiteUsingModernMethodsOfConstruction(SiteUsingModernMethodsOfConstruction usingModernMethodsOfConstruction, bool expectedCanBeAccessed)
     {
         var modernMethodsOfConstruction = new SiteModernMethodsOfConstruction(usingModernMethodsOfConstruction);

--- a/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
+++ b/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
@@ -136,7 +136,7 @@ public class SiteController : WorkflowController<SiteWorkflowState>
             return View(nameof(Name), model);
         }
 
-        return await Continue(new { siteId = result.ReturnedData.Value });
+        return await ContinueWithRedirect(new { siteId = result.ReturnedData.Value });
     }
 
     [HttpGet("{siteId}/section-106-general-agreement")]

--- a/src/HE.Investment.AHP.WWW/Models/Site/Factories/SiteSummaryViewModelFactory.cs
+++ b/src/HE.Investment.AHP.WWW/Models/Site/Factories/SiteSummaryViewModelFactory.cs
@@ -343,18 +343,23 @@ public class SiteSummaryViewModelFactory : ISiteSummaryViewModelFactory
             new("MMC", SummaryAnswerHelper.ToEnum(mmc.UsingModernMethodsOfConstruction), createAction(nameof(Controller.MmcUsing)), IsEditable: isEditable),
         };
 
-        if (mmc.UsingModernMethodsOfConstruction == SiteUsingModernMethodsOfConstruction.Yes)
-        {
-            summary.Add(new SectionSummaryItemModel(
+        summary.AddWhen(
+            new SectionSummaryItemModel(
                 "Barriers",
                 mmc.InformationBarriers.ToOneElementList(),
                 createAction(nameof(Controller.MmcInformation)),
-                IsEditable: isEditable));
-            summary.Add(new SectionSummaryItemModel(
+                IsEditable: isEditable),
+            mmc.UsingModernMethodsOfConstruction is SiteUsingModernMethodsOfConstruction.Yes or SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes);
+        summary.AddWhen(
+            new SectionSummaryItemModel(
                 "Impact on developments",
                 mmc.InformationImpact.ToOneElementList(),
                 createAction(nameof(Controller.MmcInformation)),
-                IsEditable: isEditable));
+                IsEditable: isEditable),
+            mmc.UsingModernMethodsOfConstruction is SiteUsingModernMethodsOfConstruction.Yes or SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes);
+
+        if (mmc.UsingModernMethodsOfConstruction == SiteUsingModernMethodsOfConstruction.Yes)
+        {
             summary.Add(new SectionSummaryItemModel(
                 "MMC categories",
                 mmc.ModernMethodsConstructionCategories?.Select(x => x.GetDescription()).ToList(),

--- a/src/HE.Investments.AHP.IntegrationTests/FillSite/Data/SiteData.cs
+++ b/src/HE.Investments.AHP.IntegrationTests/FillSite/Data/SiteData.cs
@@ -129,8 +129,6 @@ public class SiteData
     public SiteUsingModernMethodsOfConstruction ChangeMmcUsingAnswer()
     {
         UsingMmc = SiteUsingModernMethodsOfConstruction.OnlyForSomeHomes;
-        InformationBarriers = string.Empty;
-        InformationImpact = string.Empty;
         MmcCategories = new List<ModernMethodsConstructionCategoriesType>();
         Mmc2DSubcategory = ModernMethodsConstruction2DSubcategoriesType.Undefined;
         Mmc3DSubcategory = ModernMethodsConstruction3DSubcategoriesType.Undefined;

--- a/src/HE.Investments.AHP.IntegrationTests/FillSite/Order01StartAhpSite.cs
+++ b/src/HE.Investments.AHP.IntegrationTests/FillSite/Order01StartAhpSite.cs
@@ -561,8 +561,8 @@ public class Order01StartAhpSite : AhpIntegrationTest
         // when
         var summary = checkAnswersPage.GetSummaryListItems();
         summary.Should().ContainKey("MMC").WithValue(SiteData.UsingMmc);
-        summary.Should().NotContainKey("Barriers");
-        summary.Should().NotContainKey("Impact on developments");
+        summary.Should().ContainKey("Barriers").WithValue(SiteData.InformationBarriers);
+        summary.Should().ContainKey("Impact on developments").WithValue(SiteData.InformationImpact);
         summary.Should().NotContainKey("MMC categories");
         summary.Should().NotContainKey("Sub-categories of 3D primary structural systems");
         summary.Should().NotContainKey("Sub-categories of 2D primary structural systems");


### PR DESCRIPTION
### 🛠 Changes being made

Open MMC information page on Site MMC section when "only for some home types" option is selected.

Additional fixes:
- fixed site name redirect from check answers page
- fixed clearing Exempt Justification when changed value on previous page

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you added some unit tests?
- [-] Have you added some integration tests?
- [-] Have you checked WCAG (included screenshot)
