### PR TITLE
AB#94040 AB#94067 Fix error messages for MMC text fields

### DIFF
--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionBarriers.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionBarriers.cs
@@ -5,7 +5,7 @@ namespace HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 public class ModernMethodsOfConstructionBarriers : LongText
 {
     public ModernMethodsOfConstructionBarriers(string? value)
-        : base(value, "ModernMethodsOfConstructionBarriers", "barriers you have experienced or foresee yourself experiencing in introducing greater levels of MMC into your development programme")
+        : base(value, "InformationBarriers", "barriers you have experienced or foresee yourself experiencing in introducing greater levels of MMC into your development programme")
     {
     }
 

--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionExpectedImpact.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionExpectedImpact.cs
@@ -5,7 +5,7 @@ namespace HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 public class ModernMethodsOfConstructionExpectedImpact : LongText
 {
     public ModernMethodsOfConstructionExpectedImpact(string? value)
-        : base(value, "ModernMethodsOfConstructionExpectedImpact", "impact you think this would have on your development programme")
+        : base(value, "FutureAdoptionExpectedImpact", "impact you think this would have on your development programme")
     {
     }
 

--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionImpact.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionImpact.cs
@@ -5,7 +5,7 @@ namespace HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 public class ModernMethodsOfConstructionImpact : LongText
 {
     public ModernMethodsOfConstructionImpact(string? value)
-        : base(value, "ModernMethodsOfConstructionImpact", "impact the use of MMC has had on your development to date")
+        : base(value, "InformationImpact", "impact the use of MMC has had on your development to date")
     {
     }
 

--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionPlans.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/Mmc/ModernMethodsOfConstructionPlans.cs
@@ -2,10 +2,10 @@ using HE.Investments.Common.Domain.ValueObjects;
 
 namespace HE.Investment.AHP.Domain.Site.ValueObjects.Mmc;
 
-public class ModernMethodsOfConstructionPlans : LongText
+public class ModernMethodsOfConstructionPlans : YourLongText
 {
     public ModernMethodsOfConstructionPlans(string? value)
-        : base(value, "ModernMethodsOfConstructionPlans", "plans for adopting Modern Methods of Construction in the future")
+        : base(value, "FutureAdoptionPlans", "plans for adopting Modern Methods of Construction in the future")
     {
     }
 

--- a/src/HE.Investments.Common/Domain/ValueObjects/LongText.cs
+++ b/src/HE.Investments.Common/Domain/ValueObjects/LongText.cs
@@ -1,49 +1,21 @@
-using HE.Investments.Common.Contract.Validators;
-using HE.Investments.Common.Extensions;
 using HE.Investments.Common.Messages;
 
 namespace HE.Investments.Common.Domain.ValueObjects;
 
-public class LongText : ValueObject
+public abstract class LongText : StringValueObject
 {
-    public LongText(
-        string? value,
-        string fieldName = nameof(LongText),
-        string noValueProvidedErrorMessage = GenericValidationError.NoValueProvided,
-        string textTooLongErrorMessage = GenericValidationError.TextTooLong)
-    {
-        var normalisedValue = value?.NormalizeLineEndings();
-
-        if (normalisedValue.IsNotProvided())
-        {
-            OperationResult.New()
-                .AddValidationError(fieldName, noValueProvidedErrorMessage)
-                .CheckErrors();
-        }
-
-        if (normalisedValue!.Length > MaximumInputLength.LongInput)
-        {
-            OperationResult.New()
-                .AddValidationError(fieldName, textTooLongErrorMessage)
-                .CheckErrors();
-        }
-
-        Value = normalisedValue;
-    }
-
-    public LongText(string? value, string fieldName, string fieldDisplayName)
-        : this(
+    protected LongText(string? value, string fieldName, string fieldDisplayName)
+        : base(
             value,
             fieldName,
-            ValidationErrorMessage.MissingRequiredField(fieldDisplayName),
-            ValidationErrorMessage.LongInputLengthExceeded(fieldDisplayName))
+            ValidationErrorMessage.MustProvideRequiredField(fieldDisplayName),
+            ValidationErrorMessage.StringLengthExceeded(fieldDisplayName, MaximumInputLength.LongInput),
+            MaximumInputLength.LongInput)
     {
     }
 
-    public string Value { get; }
-
-    protected override IEnumerable<object> GetAtomicValues()
+    protected LongText(string? value, string fieldName, string noValueProvidedErrorMessage, string textTooLongErrorMessage)
+        : base(value, fieldName, noValueProvidedErrorMessage, textTooLongErrorMessage, MaximumInputLength.LongInput)
     {
-        yield return Value;
     }
 }

--- a/src/HE.Investments.Common/Domain/ValueObjects/StringValueObject.cs
+++ b/src/HE.Investments.Common/Domain/ValueObjects/StringValueObject.cs
@@ -12,6 +12,7 @@ public abstract class StringValueObject : ValueObject
         string textTooLongErrorMessage,
         int maxLength)
     {
+        value = value?.Trim().NormalizeLineEndings();
         if (value.IsNotProvided())
         {
             OperationResult.New()
@@ -19,8 +20,7 @@ public abstract class StringValueObject : ValueObject
                 .CheckErrors();
         }
 
-        value = value!.Trim();
-        if (value.Length > maxLength)
+        if (value!.Length > maxLength)
         {
             OperationResult.New()
                 .AddValidationError(fieldName, textTooLongErrorMessage)

--- a/src/HE.Investments.Common/Domain/ValueObjects/YourLongText.cs
+++ b/src/HE.Investments.Common/Domain/ValueObjects/YourLongText.cs
@@ -1,0 +1,16 @@
+using HE.Investments.Common.Messages;
+
+namespace HE.Investments.Common.Domain.ValueObjects;
+
+public abstract class YourLongText : StringValueObject
+{
+    protected YourLongText(string? value, string fieldName, string fieldDisplayName)
+        : base(
+            value,
+            fieldName,
+            ValidationErrorMessage.MustProvideYourRequiredField(fieldDisplayName),
+            ValidationErrorMessage.YourStringLengthExceeded(fieldDisplayName, MaximumInputLength.LongInput),
+            MaximumInputLength.LongInput)
+    {
+    }
+}


### PR DESCRIPTION
### 🛠 Changes being made

Fixed:
- plans error message (from "the" to "your")
- display error message above field
- order of error messages

### 📸 Screenshots (optional)

![Zrzut ekranu 2024-04-08 121818](https://github.com/homesengland/he-ssp/assets/24436849/5a6840b0-2a90-4e28-91c3-2dad73c41b54)
![Zrzut ekranu 2024-04-08 121913](https://github.com/homesengland/he-ssp/assets/24436849/9eabbf2f-b019-44dd-b5d3-2fbc610af913)


### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [-] Have you added some unit tests?
- [-] Have you added some integration tests?
- [-] Have you checked WCAG (included screenshot)
