### PR TITLE
Prefill AHP site, without CRM integration.

### DIFF
--- a/src/HE.Investment.AHP.Contract/HE.Investment.AHP.Contract.csproj
+++ b/src/HE.Investment.AHP.Contract/HE.Investment.AHP.Contract.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HE.Investments.Common.Contract\HE.Investments.Common.Contract.csproj" />
+    <ProjectReference Include="..\HE.Investments.FrontDoor.Shared\HE.Investments.FrontDoor.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/HE.Investment.AHP.Contract/PrefillData/AhpSitePrefillData.cs
+++ b/src/HE.Investment.AHP.Contract/PrefillData/AhpSitePrefillData.cs
@@ -1,0 +1,6 @@
+namespace HE.Investment.AHP.Contract.PrefillData;
+
+public record AhpSitePrefillData(string? LocalAuthorityName)
+{
+    public static AhpSitePrefillData Empty => new(LocalAuthorityName: null);
+}

--- a/src/HE.Investment.AHP.Contract/PrefillData/NewAhpSitePrefillData.cs
+++ b/src/HE.Investment.AHP.Contract/PrefillData/NewAhpSitePrefillData.cs
@@ -1,0 +1,3 @@
+namespace HE.Investment.AHP.Contract.PrefillData;
+
+public record NewAhpSitePrefillData(string? SiteName);

--- a/src/HE.Investment.AHP.Contract/PrefillData/Queries/GetAhpSitePrefillDataQuery.cs
+++ b/src/HE.Investment.AHP.Contract/PrefillData/Queries/GetAhpSitePrefillDataQuery.cs
@@ -1,0 +1,6 @@
+using HE.Investment.AHP.Contract.Site;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.PrefillData.Queries;
+
+public record GetAhpSitePrefillDataQuery(SiteId SiteId) : IRequest<AhpSitePrefillData>;

--- a/src/HE.Investment.AHP.Contract/PrefillData/Queries/GetNewAhpSitePrefillDataQuery.cs
+++ b/src/HE.Investment.AHP.Contract/PrefillData/Queries/GetNewAhpSitePrefillDataQuery.cs
@@ -1,0 +1,6 @@
+using HE.Investments.FrontDoor.Shared.Project;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.PrefillData.Queries;
+
+public record GetNewAhpSitePrefillDataQuery(FrontDoorProjectId ProjectId, FrontDoorSiteId SiteId) : IRequest<NewAhpSitePrefillData>;

--- a/src/HE.Investment.AHP.Contract/Site/Commands/ProvideNameCommand.cs
+++ b/src/HE.Investment.AHP.Contract/Site/Commands/ProvideNameCommand.cs
@@ -1,6 +1,8 @@
 using HE.Investments.Common.Contract.Validators;
+using HE.Investments.FrontDoor.Shared.Project;
 using MediatR;
 
 namespace HE.Investment.AHP.Contract.Site.Commands;
 
-public record ProvideNameCommand(string? SiteId, string? Name) : IRequest<OperationResult<SiteId>>;
+public record ProvideNameCommand(SiteId? SiteId, FrontDoorProjectId? FrontDoorProjectId, FrontDoorSiteId? FrontDoorSiteId, string? Name)
+    : IRequest<OperationResult<SiteId>>;

--- a/src/HE.Investment.AHP.Contract/Site/SiteId.cs
+++ b/src/HE.Investment.AHP.Contract/Site/SiteId.cs
@@ -1,4 +1,5 @@
 using HE.Investments.Common.Contract;
+using HE.Investments.Common.Extensions;
 
 namespace HE.Investment.AHP.Contract.Site;
 
@@ -14,6 +15,8 @@ public record SiteId : StringIdValueObject
     }
 
     public static SiteId New() => new();
+
+    public static SiteId? Create(string? id) => id.IsProvided() ? new SiteId(id!) : null;
 
     public override string ToString()
     {

--- a/src/HE.Investment.AHP.Domain.Tests/Site/TestDataBuilders/SiteEntityBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/TestDataBuilders/SiteEntityBuilder.cs
@@ -19,7 +19,7 @@ namespace HE.Investment.AHP.Domain.Tests.Site.TestDataBuilders;
 public class SiteEntityBuilder : TestObjectBuilder<SiteEntityBuilder, SiteEntity>
 {
     private SiteEntityBuilder()
-        : base(SiteEntity.NewSite())
+        : base(SiteEntity.NewSite(null, null))
     {
     }
 

--- a/src/HE.Investment.AHP.Domain/Config/DomainModule.cs
+++ b/src/HE.Investment.AHP.Domain/Config/DomainModule.cs
@@ -17,18 +17,21 @@ using HE.Investment.AHP.Domain.HomeTypes.Mappers;
 using HE.Investment.AHP.Domain.HomeTypes.Repositories;
 using HE.Investment.AHP.Domain.HomeTypes.Services;
 using HE.Investment.AHP.Domain.HomeTypes.ValueObjects;
+using HE.Investment.AHP.Domain.PrefillData.Repositories;
 using HE.Investment.AHP.Domain.Programme;
 using HE.Investment.AHP.Domain.Programme.Config;
 using HE.Investment.AHP.Domain.Programme.Crm;
 using HE.Investment.AHP.Domain.Scheme.Repositories;
 using HE.Investment.AHP.Domain.Scheme.Services;
 using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investment.AHP.Domain.Site.Mappers;
 using HE.Investment.AHP.Domain.Site.Repositories;
 using HE.Investments.Account.Shared.Config;
 using HE.Investments.Common;
 using HE.Investments.Common.CRM.Config;
 using HE.Investments.Common.Extensions;
 using HE.Investments.Common.Utils;
+using HE.Investments.FrontDoor.Shared.Config;
 using MediatR.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Org::HE.Investments.Organisation.LocalAuthorities.Repositories;
@@ -41,6 +44,7 @@ public static class DomainModule
     {
         services.AddAccountSharedModule();
         services.AddCommonCrmModule();
+        services.AddFrontDoorSharedModule();
         services.AddScoped<IDateTimeProvider, DateTimeProvider>();
         services.AddTransient(typeof(IRequestExceptionHandler<,,>), typeof(DomainValidationHandler<,,>));
 
@@ -56,6 +60,7 @@ public static class DomainModule
         AddSite(services);
         AddDelivery(services);
         AddProgramme(services);
+        AddPrefillData(services);
     }
 
     private static void AddHomeTypes(IServiceCollection services)
@@ -107,6 +112,7 @@ public static class DomainModule
         services.AddScoped<ISiteRepository, SiteRepository>();
         services.AddScoped<ILocalAuthorityRepository, LocalAuthorityRepository>();
         services.AddScoped<IAhgLocalAuthorityRepository, AhgLocalAuthorityRepository>();
+        services.AddSingleton<IAhpPlanningStatusMapper, AhpPlanningStatusMapper>();
     }
 
     private static void AddDelivery(IServiceCollection services)
@@ -122,5 +128,10 @@ public static class DomainModule
         services.AddScoped<IAhpProgrammeRepository, AhpProgrammeRepository>();
         services.AddScoped<IProgrammeCrmContext, ProgrammeCrmContext>();
         services.AddAppConfiguration<IProgrammeSettings, ProgrammeSettings>();
+    }
+
+    private static void AddPrefillData(IServiceCollection services)
+    {
+        services.AddScoped<IAhpPrefillDataRepository, AhpPrefillDataRepository>();
     }
 }

--- a/src/HE.Investment.AHP.Domain/PrefillData/Data/AhpSitePrefillData.cs
+++ b/src/HE.Investment.AHP.Domain/PrefillData/Data/AhpSitePrefillData.cs
@@ -1,0 +1,11 @@
+using HE.Investments.Common.Contract.Enum;
+using HE.Investments.FrontDoor.Shared.Project;
+
+namespace HE.Investment.AHP.Domain.PrefillData.Data;
+
+public record AhpSitePrefillData(
+    FrontDoorProjectId ProjectId,
+    FrontDoorSiteId SiteId,
+    string? SiteName,
+    string? LocalAuthorityName,
+    SitePlanningStatus PlanningStatus);

--- a/src/HE.Investment.AHP.Domain/PrefillData/QueryHandlers/GetAhpSitePrefillDataQueryHandler.cs
+++ b/src/HE.Investment.AHP.Domain/PrefillData/QueryHandlers/GetAhpSitePrefillDataQueryHandler.cs
@@ -1,0 +1,39 @@
+using HE.Investment.AHP.Contract.PrefillData;
+using HE.Investment.AHP.Contract.PrefillData.Queries;
+using HE.Investment.AHP.Domain.PrefillData.Repositories;
+using HE.Investment.AHP.Domain.Site.Repositories;
+using HE.Investments.Account.Shared;
+using HE.Investments.Common.Extensions;
+using MediatR;
+
+namespace HE.Investment.AHP.Domain.PrefillData.QueryHandlers;
+
+public class GetAhpSitePrefillDataQueryHandler : IRequestHandler<GetAhpSitePrefillDataQuery, AhpSitePrefillData>
+{
+    private readonly ISiteRepository _siteRepository;
+
+    private readonly IAhpPrefillDataRepository _prefillDataRepository;
+
+    private readonly IAccountUserContext _accountUserContext;
+
+    public GetAhpSitePrefillDataQueryHandler(ISiteRepository siteRepository, IAhpPrefillDataRepository prefillDataRepository, IAccountUserContext accountUserContext)
+    {
+        _siteRepository = siteRepository;
+        _prefillDataRepository = prefillDataRepository;
+        _accountUserContext = accountUserContext;
+    }
+
+    public async Task<AhpSitePrefillData> Handle(GetAhpSitePrefillDataQuery request, CancellationToken cancellationToken)
+    {
+        var userAccount = await _accountUserContext.GetSelectedAccount();
+        var site = await _siteRepository.GetSite(request.SiteId, userAccount, cancellationToken);
+
+        if (site.FrontDoorProjectId.IsProvided() && site.FrontDoorSiteId.IsProvided())
+        {
+            var prefillData = await _prefillDataRepository.GetAhpSitePrefillData(site.FrontDoorProjectId!, site.FrontDoorSiteId!, cancellationToken);
+            return new AhpSitePrefillData(prefillData.LocalAuthorityName);
+        }
+
+        return AhpSitePrefillData.Empty;
+    }
+}

--- a/src/HE.Investment.AHP.Domain/PrefillData/QueryHandlers/GetNewAhpSitePrefillDataQueryHandler.cs
+++ b/src/HE.Investment.AHP.Domain/PrefillData/QueryHandlers/GetNewAhpSitePrefillDataQueryHandler.cs
@@ -1,0 +1,26 @@
+using HE.Investment.AHP.Contract.PrefillData;
+using HE.Investment.AHP.Contract.PrefillData.Queries;
+using HE.Investment.AHP.Domain.PrefillData.Repositories;
+using MediatR;
+
+namespace HE.Investment.AHP.Domain.PrefillData.QueryHandlers;
+
+public class GetNewAhpSitePrefillDataQueryHandler : IRequestHandler<GetNewAhpSitePrefillDataQuery, NewAhpSitePrefillData>
+{
+    private readonly IAhpPrefillDataRepository _prefillDataRepository;
+
+    public GetNewAhpSitePrefillDataQueryHandler(IAhpPrefillDataRepository prefillDataRepository)
+    {
+        _prefillDataRepository = prefillDataRepository;
+    }
+
+    public async Task<NewAhpSitePrefillData> Handle(GetNewAhpSitePrefillDataQuery request, CancellationToken cancellationToken)
+    {
+        var prefillData = await _prefillDataRepository.GetAhpSitePrefillData(
+            request.ProjectId,
+            request.SiteId,
+            cancellationToken);
+
+        return new NewAhpSitePrefillData(prefillData.SiteName);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/PrefillData/Repositories/AhpPrefillDataRepository.cs
+++ b/src/HE.Investment.AHP.Domain/PrefillData/Repositories/AhpPrefillDataRepository.cs
@@ -1,0 +1,27 @@
+using HE.Investment.AHP.Domain.PrefillData.Data;
+using HE.Investments.FrontDoor.Shared.Project;
+using HE.Investments.FrontDoor.Shared.Project.Repositories;
+
+namespace HE.Investment.AHP.Domain.PrefillData.Repositories;
+
+public class AhpPrefillDataRepository : IAhpPrefillDataRepository
+{
+    private readonly IPrefillDataRepository _prefillDataRepository;
+
+    public AhpPrefillDataRepository(IPrefillDataRepository prefillDataRepository)
+    {
+        _prefillDataRepository = prefillDataRepository;
+    }
+
+    public async Task<AhpSitePrefillData> GetAhpSitePrefillData(FrontDoorProjectId projectId, FrontDoorSiteId siteId, CancellationToken cancellationToken)
+    {
+        var prefillData = await _prefillDataRepository.GetSitePrefillData(projectId, siteId, cancellationToken);
+
+        return new AhpSitePrefillData(
+            projectId,
+            siteId,
+            prefillData.Name,
+            prefillData.LocalAuthorityName,
+            prefillData.PlanningStatus);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/PrefillData/Repositories/IAhpPrefillDataRepository.cs
+++ b/src/HE.Investment.AHP.Domain/PrefillData/Repositories/IAhpPrefillDataRepository.cs
@@ -1,0 +1,10 @@
+using HE.Investment.AHP.Domain.PrefillData.Data;
+using HE.Investments.Account.Shared.User;
+using HE.Investments.FrontDoor.Shared.Project;
+
+namespace HE.Investment.AHP.Domain.PrefillData.Repositories;
+
+public interface IAhpPrefillDataRepository
+{
+    Task<AhpSitePrefillData> GetAhpSitePrefillData(FrontDoorProjectId projectId, FrontDoorSiteId siteId, CancellationToken cancellationToken);
+}

--- a/src/HE.Investment.AHP.Domain/Site/Entities/SiteEntity.cs
+++ b/src/HE.Investment.AHP.Domain/Site/Entities/SiteEntity.cs
@@ -13,6 +13,7 @@ using HE.Investments.Common.Contract.Validators;
 using HE.Investments.Common.Domain;
 using HE.Investments.Common.Extensions;
 using HE.Investments.Common.Messages;
+using HE.Investments.FrontDoor.Shared.Project;
 using LocalAuthority = Org::HE.Investments.Organisation.LocalAuthorities.ValueObjects.LocalAuthority;
 using Section106 = HE.Investment.AHP.Domain.Site.ValueObjects.Section106;
 using SiteModernMethodsOfConstruction = HE.Investment.AHP.Domain.Site.ValueObjects.Mmc.SiteModernMethodsOfConstruction;
@@ -44,7 +45,9 @@ public class SiteEntity : DomainEntity, IQuestion
         SiteRuralClassification? ruralClassification = null,
         EnvironmentalImpact? environmentalImpact = null,
         SiteModernMethodsOfConstruction? modernMethodsOfConstruction = null,
-        SiteProcurements? siteProcurements = null)
+        SiteProcurements? siteProcurements = null,
+        FrontDoorProjectId? frontDoorProjectId = null,
+        FrontDoorSiteId? frontDoorSiteId = null)
     {
         Id = id;
         Name = name;
@@ -64,9 +67,15 @@ public class SiteEntity : DomainEntity, IQuestion
         EnvironmentalImpact = environmentalImpact;
         ModernMethodsOfConstruction = modernMethodsOfConstruction ?? new SiteModernMethodsOfConstruction();
         Procurements = siteProcurements ?? new SiteProcurements();
+        FrontDoorProjectId = frontDoorProjectId;
+        FrontDoorSiteId = frontDoorSiteId;
     }
 
     public SiteId Id { get; set; }
+
+    public FrontDoorProjectId? FrontDoorProjectId { get; }
+
+    public FrontDoorSiteId? FrontDoorSiteId { get; }
 
     public SiteName Name { get; private set; }
 
@@ -104,9 +113,9 @@ public class SiteEntity : DomainEntity, IQuestion
 
     public bool IsModified => _modificationTracker.IsModified;
 
-    public static SiteEntity NewSite()
+    public static SiteEntity NewSite(FrontDoorProjectId? projectId, FrontDoorSiteId? siteId)
     {
-        return new SiteEntity(SiteId.New(), new SiteName("New Site"));
+        return new SiteEntity(SiteId.New(), new SiteName($"New Site - {Guid.NewGuid()}"), frontDoorProjectId: projectId, frontDoorSiteId: siteId);
     }
 
     public async Task ProvideName(SiteName siteName, ISiteNameExist siteNameExist, CancellationToken cancellationToken)

--- a/src/HE.Investment.AHP.Domain/Site/Mappers/AhpPlanningStatusMapper.cs
+++ b/src/HE.Investment.AHP.Domain/Site/Mappers/AhpPlanningStatusMapper.cs
@@ -1,0 +1,7 @@
+using HE.Investments.Common.CRM.Mappers;
+
+namespace HE.Investment.AHP.Domain.Site.Mappers;
+
+public class AhpPlanningStatusMapper : InternalPlanningStatusMapper, IAhpPlanningStatusMapper
+{
+}

--- a/src/HE.Investment.AHP.Domain/Site/Mappers/IAhpPlanningStatusMapper.cs
+++ b/src/HE.Investment.AHP.Domain/Site/Mappers/IAhpPlanningStatusMapper.cs
@@ -1,0 +1,7 @@
+using HE.Investments.Common.CRM.Mappers;
+
+namespace HE.Investment.AHP.Domain.Site.Mappers;
+
+public interface IAhpPlanningStatusMapper : IPlanningStatusMapper
+{
+}

--- a/src/HE.Investment.AHP.Domain/Site/Mappers/SiteDtoToSiteEntityMapper.cs
+++ b/src/HE.Investment.AHP.Domain/Site/Mappers/SiteDtoToSiteEntityMapper.cs
@@ -38,7 +38,7 @@ public static class SiteDtoToSiteEntityMapper
     private static readonly SiteProcurementMapper SiteProcurementMapper = new();
     private static readonly SiteStatusMapper SiteStatusMapper = new();
 
-    public static SiteEntity Map(SiteDto dto, IPlanningStatusMapper planningStatusMapper)
+    public static SiteEntity Map(SiteDto dto, IAhpPlanningStatusMapper planningStatusMapper)
     {
         return new SiteEntity(
             new SiteId(dto.id),
@@ -58,7 +58,9 @@ public static class SiteDtoToSiteEntityMapper
             CreateSiteRuralClassification(dto.ruralDetails),
             string.IsNullOrWhiteSpace(dto.environmentalImpact) ? null : new EnvironmentalImpact(dto.environmentalImpact),
             CreateMmc(dto.modernMethodsOfConstruction),
-            new SiteProcurements(MapCollection(dto.procurementMechanisms, SiteProcurementMapper)));
+            new SiteProcurements(MapCollection(dto.procurementMechanisms, SiteProcurementMapper)),
+            frontDoorProjectId: null, // TODO: use value from CRM when added
+            frontDoorSiteId: null);
     }
 
     private static Section106 CreateSection106(Section106Dto dto)
@@ -81,7 +83,7 @@ public static class SiteDtoToSiteEntityMapper
             : new Org::HE.Investments.Organisation.LocalAuthorities.ValueObjects.LocalAuthority(new LocalAuthorityCode(id), name);
     }
 
-    private static PlanningDetails CreatePlanningDetails(PlanningDetailsDto dto, IPlanningStatusMapper planningStatusMapper)
+    private static PlanningDetails CreatePlanningDetails(PlanningDetailsDto dto, IAhpPlanningStatusMapper planningStatusMapper)
     {
         if (dto.planningStatus == null)
         {

--- a/src/HE.Investment.AHP.Domain/Site/Repositories/SiteRepository.cs
+++ b/src/HE.Investment.AHP.Domain/Site/Repositories/SiteRepository.cs
@@ -8,7 +8,6 @@ using HE.Investment.AHP.Domain.Site.ValueObjects;
 using HE.Investments.Account.Shared.User;
 using HE.Investments.Common.Contract.Exceptions;
 using HE.Investments.Common.Contract.Pagination;
-using HE.Investments.Common.CRM.Mappers;
 
 namespace HE.Investment.AHP.Domain.Site.Repositories;
 
@@ -16,9 +15,9 @@ public class SiteRepository : ISiteRepository
 {
     private readonly ISiteCrmContext _siteCrmContext;
 
-    private readonly IPlanningStatusMapper _planningStatusMapper;
+    private readonly IAhpPlanningStatusMapper _planningStatusMapper;
 
-    public SiteRepository(ISiteCrmContext siteCrmContext, IPlanningStatusMapper planningStatusMapper)
+    public SiteRepository(ISiteCrmContext siteCrmContext, IAhpPlanningStatusMapper planningStatusMapper)
     {
         _siteCrmContext = siteCrmContext;
         _planningStatusMapper = planningStatusMapper;
@@ -56,11 +55,6 @@ public class SiteRepository : ISiteRepository
 
     public async Task<SiteEntity> GetSite(SiteId siteId, UserAccount userAccount, CancellationToken cancellationToken)
     {
-        if (siteId.IsNew)
-        {
-            return SiteEntity.NewSite();
-        }
-
         var site = await _siteCrmContext.GetById(siteId.Value, cancellationToken) ?? throw new NotFoundException("Site not found", siteId);
 
         return SiteDtoToSiteEntityMapper.Map(site, _planningStatusMapper);

--- a/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
+++ b/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
@@ -1,5 +1,6 @@
 using He.AspNetCore.Mvc.Gds.Components.Extensions;
 using HE.Investment.AHP.Contract.Common.Enums;
+using HE.Investment.AHP.Contract.PrefillData.Queries;
 using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Contract.Site.Commands;
 using HE.Investment.AHP.Contract.Site.Commands.Mmc;
@@ -25,6 +26,7 @@ using HE.Investments.Common.WWW.Controllers;
 using HE.Investments.Common.WWW.Extensions;
 using HE.Investments.Common.WWW.Models;
 using HE.Investments.Common.WWW.Routing;
+using HE.Investments.FrontDoor.Shared.Project;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using LocalAuthority = HE.Investment.AHP.Contract.Site.LocalAuthority;
@@ -109,22 +111,27 @@ public class SiteController : WorkflowController<SiteWorkflowState>
 
     [HttpGet("name")]
     [WorkflowState(SiteWorkflowState.Name)]
-    public async Task<IActionResult> Name([FromQuery] string? siteId, CancellationToken cancellationToken)
+    public async Task<IActionResult> Name([FromQuery] string? siteId, [FromQuery] string? fdProjectId, [FromQuery] string? fdSiteId, CancellationToken cancellationToken)
     {
-        SiteModel siteModel = new();
-        if (siteId.IsProvided())
-        {
-            siteModel = await _mediator.Send(new GetSiteQuery(siteId!), cancellationToken);
-        }
-
-        return View("Name", siteModel);
+        return View("Name", await CreateSiteNameModel(siteId, fdProjectId, fdSiteId, cancellationToken));
     }
 
     [HttpPost("name")]
     [WorkflowState(SiteWorkflowState.Name)]
-    public async Task<IActionResult> NamePost([FromQuery] string? siteId, SiteModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> NamePost(
+        [FromQuery] string? siteId,
+        [FromQuery] string? fdProjectId,
+        [FromQuery] string? fdSiteId,
+        SiteModel model,
+        CancellationToken cancellationToken)
     {
-        var result = await _mediator.Send(new ProvideNameCommand(siteId ?? model.Id, model.Name), cancellationToken);
+        var result = await _mediator.Send(
+            new ProvideNameCommand(
+                SiteId.Create(siteId ?? model.Id),
+                FrontDoorProjectId.Create(fdProjectId),
+                FrontDoorSiteId.Create(fdSiteId),
+                model.Name),
+            cancellationToken);
 
         if (result.HasValidationErrors)
         {
@@ -266,7 +273,8 @@ public class SiteController : WorkflowController<SiteWorkflowState>
     public async Task<IActionResult> LocalAuthoritySearch(string siteId, CancellationToken cancellationToken)
     {
         await GetSiteBasicDetails(siteId, cancellationToken);
-        return View(nameof(LocalAuthoritySearch), new LocalAuthorities { SiteId = siteId });
+        var prefillData = await _mediator.Send(new GetAhpSitePrefillDataQuery(new SiteId(siteId)), cancellationToken);
+        return View(nameof(LocalAuthoritySearch), new LocalAuthorities { SiteId = siteId, Phrase = prefillData.LocalAuthorityName });
     }
 
     [HttpPost("{siteId}/local-authority/search")]
@@ -917,6 +925,24 @@ public class SiteController : WorkflowController<SiteWorkflowState>
                 return View(viewName, model);
             },
             cancellationToken);
+    }
+
+    private async Task<SiteModel> CreateSiteNameModel(string? siteId, string? fdProjectId, string? fdSiteId, CancellationToken cancellationToken)
+    {
+        if (siteId.IsProvided())
+        {
+            return await _mediator.Send(new GetSiteQuery(siteId!), cancellationToken);
+        }
+
+        if (fdProjectId.IsProvided() && fdSiteId.IsProvided())
+        {
+            var prefillData = await _mediator.Send(
+                new GetNewAhpSitePrefillDataQuery(new FrontDoorProjectId(fdProjectId!), new FrontDoorSiteId(fdSiteId!)),
+                cancellationToken);
+            return new SiteModel { Name = prefillData.SiteName ?? string.Empty };
+        }
+
+        return new SiteModel();
     }
 
     private async Task<SiteModel> GetSiteDetails(string siteId, CancellationToken cancellationToken)

--- a/src/HE.Investment.AHP.WWW/Views/Site/Name.cshtml
+++ b/src/HE.Investment.AHP.WWW/Views/Site/Name.cshtml
@@ -9,7 +9,7 @@
 <gds-div-grid-column-two-thirds>
     <gds-back-link href="@Url.Action("Index", "Application")" text="Back" class="govuk-!-margin-bottom-8"></gds-back-link>
     @await Html.PartialAsync("~/Partials/Errors/_ErrorSummaryPartial.cshtml")
-    <form asp-controller="Site" asp-action="Name" asp-route-redirect="@Context.Request.Query["redirect"]" asp-method="post" novalidate>
+    <form asp-controller="Site" asp-action="Name" asp-route-fdProjectId="@Context.Request.Query["fdProjectId"]" asp-route-fdSiteId="@Context.Request.Query["fdSiteId"]" asp-route-redirect="@Context.Request.Query["redirect"]" asp-method="post" novalidate>
 
         <vc:text-input
             title="@SitePageTitles.SiteName"

--- a/src/HE.Investments.Common.CRM/Mappers/InternalPlanningStatusMapper.cs
+++ b/src/HE.Investments.Common.CRM/Mappers/InternalPlanningStatusMapper.cs
@@ -3,7 +3,8 @@ using HE.Investments.Common.CRM.Model;
 
 namespace HE.Investments.Common.CRM.Mappers;
 
-internal class InternalPlanningStatusMapper : EnumMapper<SitePlanningStatus>, IPlanningStatusMapper
+// TODO: remove this class and move mapping to AhpPlanningStatusMapper when removing UseExternalFrontDoorTables Feature Flag
+public class InternalPlanningStatusMapper : EnumMapper<SitePlanningStatus>, IPlanningStatusMapper
 {
     protected override IDictionary<SitePlanningStatus, int?> Mapping => new Dictionary<SitePlanningStatus, int?>
     {

--- a/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorProjectId.cs
+++ b/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorProjectId.cs
@@ -1,4 +1,5 @@
 using HE.Investments.Common.Contract;
+using HE.Investments.Common.Extensions;
 
 namespace HE.Investments.FrontDoor.Shared.Project;
 
@@ -14,6 +15,8 @@ public record FrontDoorProjectId : StringIdValueObject
     }
 
     public static FrontDoorProjectId New() => new();
+
+    public static FrontDoorProjectId? Create(string? id) => id.IsProvided() ? new FrontDoorProjectId(id!) : null;
 
     public override string ToString()
     {

--- a/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorSiteId.cs
+++ b/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorSiteId.cs
@@ -1,4 +1,5 @@
 using HE.Investments.Common.Contract;
+using HE.Investments.Common.Extensions;
 
 namespace HE.Investments.FrontDoor.Shared.Project;
 
@@ -14,6 +15,8 @@ public record FrontDoorSiteId : StringIdValueObject
     }
 
     public static FrontDoorSiteId New() => new();
+
+    public static FrontDoorSiteId? Create(string? id) => id.IsProvided() ? new FrontDoorSiteId(id!) : null;
 
     public override string ToString()
     {

--- a/src/HE.Investments.Loans.Contract/PrefillData/LoanApplicationPrefillData.cs
+++ b/src/HE.Investments.Loans.Contract/PrefillData/LoanApplicationPrefillData.cs
@@ -1,3 +1,0 @@
-namespace HE.Investments.Loans.Contract.PrefillData;
-
-public record LoanApplicationPrefillData(string ApplicationName);


### PR DESCRIPTION
### 🛠 Changes being made

Prefilling some site data.
1. Name - when site name page get FD project and site Ids in query parameter
2. Local authority name
3. Planning status

TODO:
- connect with CRM when fields will be added
- fix Planning Status mapping after removing HE feature toggle

### 🏎 Quality check

- [x] Have you performed local tests?
- [ ] Are integration tests passing locally?
- [ ] Have you added some unit tests?
- [ ] Have you added some integration tests?
- [ ] Have you checked WCAG (included screenshot)
