### PR TITLE
AB#95445 Do not validate number of homes on Home Types list page.

### DIFF
--- a/src/HE.Investment.AHP.Domain.Tests/HomeTypes/Entities/HomeTypesEntityTests/CompleteSectionTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/HomeTypes/Entities/HomeTypesEntityTests/CompleteSectionTests.cs
@@ -124,4 +124,19 @@ public class CompleteSectionTests
         testCandidate.Status.Should().Be(SectionStatus.Completed);
         testCandidate.IsStatusChanged.Should().BeTrue();
     }
+
+    [Fact]
+    public void ShouldChangeStatusToCompleted_WhenFinishAnswerIsYesAndExpectedNumberOfHomesIsNotProvided()
+    {
+        // given
+        var homeType = new HomeTypeEntityBuilder().WithName("Mercury").WithStatus(SectionStatus.Completed).Build();
+        var testCandidate = new HomeTypesEntityBuilder().WithHomeTypes(homeType).Build();
+
+        // when
+        testCandidate.CompleteSection(FinishHomeTypesAnswer.Yes, null);
+
+        // then
+        testCandidate.Status.Should().Be(SectionStatus.Completed);
+        testCandidate.IsStatusChanged.Should().BeTrue();
+    }
 }

--- a/src/HE.Investment.AHP.Domain/HomeTypes/CommandHandlers/SaveFinishHomeTypesAnswerCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/HomeTypes/CommandHandlers/SaveFinishHomeTypesAnswerCommandHandler.cs
@@ -28,9 +28,11 @@ public class SaveFinishHomeTypesAnswerCommandHandler : HomeTypeCommandHandlerBas
     {
         var account = await _accountUserContext.GetSelectedAccount();
         var homeTypes = await _repository.GetByApplicationId(request.ApplicationId, account, cancellationToken);
-        var scheme = await _schemeRepository.GetByApplicationId(request.ApplicationId, account, false, cancellationToken);
+        int? expectedNumberOfHomes = request.IsCheckOnly
+            ? null
+            : (await _schemeRepository.GetByApplicationId(request.ApplicationId, account, false, cancellationToken)).Funding.HousesToDeliver ?? 0;
 
-        var validationErrors = PerformWithValidation(() => homeTypes.CompleteSection(request.FinishHomeTypesAnswer, scheme.Funding.HousesToDeliver ?? 0));
+        var validationErrors = PerformWithValidation(() => homeTypes.CompleteSection(request.FinishHomeTypesAnswer, expectedNumberOfHomes));
         if (validationErrors.Any())
         {
             return new OperationResult(validationErrors);

--- a/src/HE.Investment.AHP.Domain/HomeTypes/Entities/HomeTypesEntity.cs
+++ b/src/HE.Investment.AHP.Domain/HomeTypes/Entities/HomeTypesEntity.cs
@@ -88,7 +88,7 @@ public class HomeTypesEntity
         entity.ChangeName(ValidateNameUniqueness(name, entity));
     }
 
-    public void CompleteSection(FinishHomeTypesAnswer finishAnswer, int expectedNumberOfHomes)
+    public void CompleteSection(FinishHomeTypesAnswer finishAnswer, int? expectedNumberOfHomes)
     {
         if (finishAnswer == FinishHomeTypesAnswer.Undefined)
         {
@@ -113,7 +113,7 @@ public class HomeTypesEntity
                     notCompletedHomeTypes.Select(x => new ErrorItem($"HomeType-{x.Id}", $"Complete {x.Name.Value} to save and continue")).ToList()));
             }
 
-            if (expectedNumberOfHomes != _homeTypes.Sum(x => x.HomeInformation.NumberOfHomes?.Value ?? 0))
+            if (expectedNumberOfHomes.HasValue && expectedNumberOfHomes != _homeTypes.Sum(x => x.HomeInformation.NumberOfHomes?.Value ?? 0))
             {
                 OperationResult.New().AddValidationError("HomeTypes", "You have not assigned all of the homes you are delivering to a home type").CheckErrors();
             }


### PR DESCRIPTION
### 🛠 Changes being made

Validate number of homes on Home Type with Schema information only on Complete Home Type page not list.

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you added some unit tests?
- [ ] Have you added some integration tests?
- [ ] Have you checked WCAG (included screenshot)
