### PR TITLE
AB#96842 Create AHP user context with consortium information.

### DIFF
--- a/src/HE.Investment.AHP.Contract/Application/AhpApplicationId.cs
+++ b/src/HE.Investment.AHP.Contract/Application/AhpApplicationId.cs
@@ -5,8 +5,8 @@ namespace HE.Investment.AHP.Contract.Application;
 
 public record AhpApplicationId : StringIdValueObject
 {
-    public AhpApplicationId(string id)
-        : base(id)
+    public AhpApplicationId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investment.AHP.Contract/Delivery/DeliveryPhaseId.cs
+++ b/src/HE.Investment.AHP.Contract/Delivery/DeliveryPhaseId.cs
@@ -5,8 +5,8 @@ namespace HE.Investment.AHP.Contract.Delivery;
 
 public record DeliveryPhaseId : StringIdValueObject
 {
-    public DeliveryPhaseId(string id)
-        : base(id)
+    public DeliveryPhaseId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investment.AHP.Contract/HomeTypes/HomeTypeId.cs
+++ b/src/HE.Investment.AHP.Contract/HomeTypes/HomeTypeId.cs
@@ -5,8 +5,8 @@ namespace HE.Investment.AHP.Contract.HomeTypes;
 
 public record HomeTypeId : StringIdValueObject
 {
-    public HomeTypeId(string id)
-        : base(id)
+    public HomeTypeId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investment.AHP.Contract/Site/SiteId.cs
+++ b/src/HE.Investment.AHP.Contract/Site/SiteId.cs
@@ -5,8 +5,8 @@ namespace HE.Investment.AHP.Contract.Site;
 
 public record SiteId : StringIdValueObject
 {
-    public SiteId(string id)
-        : base(id)
+    public SiteId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investment.AHP.Domain/Config/DomainModule.cs
+++ b/src/HE.Investment.AHP.Domain/Config/DomainModule.cs
@@ -26,6 +26,7 @@ using HE.Investment.AHP.Domain.Scheme.Services;
 using HE.Investment.AHP.Domain.Scheme.ValueObjects;
 using HE.Investment.AHP.Domain.Site.Crm;
 using HE.Investment.AHP.Domain.Site.Repositories;
+using HE.Investment.AHP.Domain.UserContext;
 using HE.Investments.Account.Shared.Config;
 using HE.Investments.Common;
 using HE.Investments.Common.Extensions;
@@ -48,6 +49,7 @@ public static class DomainModule
         services.AddFrontDoorSharedModule();
         services.AddScoped<IDateTimeProvider, DateTimeProvider>();
         services.AddTransient(typeof(IRequestExceptionHandler<,,>), typeof(DomainValidationHandler<,,>));
+        services.AddScoped<IAhpUserContext, AhpUserContext>();
 
         services
             .AddProgramme()

--- a/src/HE.Investment.AHP.Domain/HE.Investment.AHP.Domain.csproj
+++ b/src/HE.Investment.AHP.Domain/HE.Investment.AHP.Domain.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\HE.Investment.AHP.Contract\HE.Investment.AHP.Contract.csproj"/>
     <ProjectReference Include="..\HE.Investments.Account.Shared\HE.Investments.Account.Shared.csproj"/>
+    <ProjectReference Include="..\HE.Investments.AHP.Consortium.Contract\HE.Investments.AHP.Consortium.Contract.csproj" />
     <ProjectReference Include="..\HE.Investments.Common.CRM\HE.Investments.Common.CRM.csproj"/>
     <ProjectReference Include="..\HE.Investments.Common\HE.Investments.Common.csproj"/>
     <ProjectReference Include="..\HE.Investments.DocumentService\HE.Investments.DocumentService.csproj"/>

--- a/src/HE.Investment.AHP.Domain/UserContext/AhpConsortiumBasicInfo.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/AhpConsortiumBasicInfo.cs
@@ -1,0 +1,11 @@
+using HE.Investments.AHP.Consortium.Contract;
+using HE.Investments.Common.Contract;
+
+namespace HE.Investment.AHP.Domain.UserContext;
+
+public record AhpConsortiumBasicInfo(ConsortiumId ConsortiumId, bool IsLeadPartner, IList<OrganisationId> ActiveMembers)
+{
+    public bool HasNoConsortium => ConsortiumId == ConsortiumId.From(Guid.Empty.ToString());
+
+    public static AhpConsortiumBasicInfo NoConsortium => new(ConsortiumId.From(Guid.Empty.ToString()), false, []);
+}

--- a/src/HE.Investment.AHP.Domain/UserContext/AhpUserAccount.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/AhpUserAccount.cs
@@ -1,0 +1,20 @@
+using HE.Investments.Account.Api.Contract.User;
+using HE.Investments.Account.Shared;
+using HE.Investments.Account.Shared.User;
+using HE.Investments.Common.Contract;
+
+namespace HE.Investment.AHP.Domain.UserContext;
+
+public record AhpUserAccount(
+    UserGlobalId UserGlobalId,
+    string UserEmail,
+    OrganisationBasicInfo? Organisation,
+    IReadOnlyCollection<UserRole> Roles,
+    AhpConsortiumBasicInfo Consortium)
+    : UserAccount(UserGlobalId, UserEmail, Organisation, Roles)
+{
+    public AhpUserAccount(UserAccount userAccount, AhpConsortiumBasicInfo consortium)
+        : this(userAccount.UserGlobalId, userAccount.UserEmail, userAccount.Organisation, userAccount.Roles, consortium)
+    {
+    }
+}

--- a/src/HE.Investment.AHP.Domain/UserContext/AhpUserContext.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/AhpUserContext.cs
@@ -1,0 +1,86 @@
+using HE.Investment.AHP.Domain.Programme.Config;
+using HE.Investments.Account.Shared;
+using HE.Investments.Account.Shared.User.Entities;
+using HE.Investments.AHP.Consortium.Contract;
+using HE.Investments.AHP.Consortium.Contract.Queries;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Extensions;
+using HE.Investments.Common.Infrastructure.Cache;
+using HE.Investments.Common.Infrastructure.Cache.Interfaces;
+using MediatR;
+
+namespace HE.Investment.AHP.Domain.UserContext;
+
+internal sealed class AhpUserContext(
+    ICacheService cacheService,
+    IAccountUserContext accountUserContext,
+    IMediator mediator,
+    IProgrammeSettings programmeSettings)
+    : IAhpUserContext
+{
+    private readonly ProgrammeId _ahpProgrammeId = new(programmeSettings.AhpProgrammeId);
+
+    private readonly Dictionary<OrganisationId, CachedEntity<AhpConsortiumBasicInfo>> _consortia = new();
+
+    public bool IsLogged => accountUserContext.IsLogged;
+
+    public UserGlobalId UserGlobalId => accountUserContext.UserGlobalId;
+
+    public string Email => accountUserContext.Email;
+
+    public async Task<AhpUserAccount> GetSelectedAccount()
+    {
+        var userAccount = await accountUserContext.GetSelectedAccount();
+        var consortium = await GetCachedAhpConsortiumInfo(userAccount.Organisation?.OrganisationId);
+
+        return new AhpUserAccount(userAccount, consortium);
+    }
+
+    public async Task<UserProfileDetails> GetProfileDetails()
+    {
+        return await accountUserContext.GetProfileDetails();
+    }
+
+    public async Task RefreshUserData()
+    {
+        await accountUserContext.RefreshUserData();
+    }
+
+    public async Task<bool> IsProfileCompleted()
+    {
+        return await accountUserContext.IsProfileCompleted();
+    }
+
+    public async Task<bool> IsLinkedWithOrganisation()
+    {
+        return await accountUserContext.IsLinkedWithOrganisation();
+    }
+
+    private async Task<AhpConsortiumBasicInfo> GetCachedAhpConsortiumInfo(OrganisationId? organisationId)
+    {
+        if (organisationId.IsNotProvided())
+        {
+            return AhpConsortiumBasicInfo.NoConsortium;
+        }
+
+        if (!_consortia.TryGetValue(organisationId!, out var consortiumCachedEntity))
+        {
+            consortiumCachedEntity = _consortia[organisationId!] = new CachedEntity<AhpConsortiumBasicInfo>(
+                cacheService,
+                $"ahp-consortium-{organisationId}",
+                async () => await GetAhpConsortiumInfo(organisationId!));
+        }
+
+        var consortium = await consortiumCachedEntity.GetAsync();
+
+        return consortium!;
+    }
+
+    private async Task<AhpConsortiumBasicInfo> GetAhpConsortiumInfo(OrganisationId organisationId)
+    {
+        var consortium = await mediator.Send(new GetOrganisationConsortiumQuery(organisationId, _ahpProgrammeId));
+        return consortium.IsProvided()
+            ? new AhpConsortiumBasicInfo(consortium!.Id, organisationId == consortium.LeadPartnerId, consortium.ActiveMembers)
+            : AhpConsortiumBasicInfo.NoConsortium;
+    }
+}

--- a/src/HE.Investment.AHP.Domain/UserContext/IAhpUserContext.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/IAhpUserContext.cs
@@ -1,0 +1,7 @@
+using HE.Investments.Account.Shared;
+
+namespace HE.Investment.AHP.Domain.UserContext;
+
+public interface IAhpUserContext : IUserAccountContext<AhpUserAccount>
+{
+}

--- a/src/HE.Investments.AHP.Consortium.Contract/ConsortiumBasicDetails.cs
+++ b/src/HE.Investments.AHP.Consortium.Contract/ConsortiumBasicDetails.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using HE.Investments.Common.Contract;
+
+namespace HE.Investments.AHP.Consortium.Contract;
+
+public record ConsortiumBasicDetails(
+    ConsortiumId Id,
+    ProgrammeId ProgrammeId,
+    OrganisationId LeadPartnerId,
+    ReadOnlyCollection<OrganisationId> ActiveMembers);

--- a/src/HE.Investments.AHP.Consortium.Contract/ConsortiumId.cs
+++ b/src/HE.Investments.AHP.Consortium.Contract/ConsortiumId.cs
@@ -5,8 +5,8 @@ namespace HE.Investments.AHP.Consortium.Contract;
 
 public record ConsortiumId : StringIdValueObject
 {
-    public ConsortiumId(string id)
-        : base(id)
+    public ConsortiumId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investments.AHP.Consortium.Contract/ProgrammeId.cs
+++ b/src/HE.Investments.AHP.Consortium.Contract/ProgrammeId.cs
@@ -1,5 +1,4 @@
 using HE.Investments.Common.Contract;
-using HE.Investments.Common.Extensions;
 
 namespace HE.Investments.AHP.Consortium.Contract;
 

--- a/src/HE.Investments.AHP.Consortium.Contract/Queries/GetOrganisationConsortiumQuery.cs
+++ b/src/HE.Investments.AHP.Consortium.Contract/Queries/GetOrganisationConsortiumQuery.cs
@@ -1,0 +1,6 @@
+using HE.Investments.Common.Contract;
+using MediatR;
+
+namespace HE.Investments.AHP.Consortium.Contract.Queries;
+
+public record GetOrganisationConsortiumQuery(OrganisationId OrganisationId, ProgrammeId ProgrammeId) : IRequest<ConsortiumBasicDetails?>;

--- a/src/HE.Investments.AHP.Consortium.Domain/Crm/ConsortiumCrmContext.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/Crm/ConsortiumCrmContext.cs
@@ -55,7 +55,7 @@ public class ConsortiumCrmContext : IConsortiumCrmContext
 
         var consortiumsList = await _service.ExecuteAsync<invln_getconsortiumsRequest, invln_getconsortiumsResponse, IList<ConsortiumDto>>(
             request,
-            x => x.invln_consortiums,
+            x => string.IsNullOrWhiteSpace(x.invln_consortiums) ? "[]" : x.invln_consortiums,
             cancellationToken);
 
         return consortiumsList;

--- a/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
@@ -38,6 +38,8 @@ public class ConsortiumEntity : IConsortiumEntity
 
     public ConsortiumMember LeadPartner { get; }
 
+    public IEnumerable<ConsortiumMember> ActiveMembers => _members.Where(x => x.Status is ConsortiumMemberStatus.Active);
+
     public IEnumerable<ConsortiumMember> Members => _members;
 
     public static async Task<ConsortiumEntity> New(ProgrammeSlim programme, ConsortiumMember leadPartner, IIsPartOfConsortium isPartOfConsortium)

--- a/src/HE.Investments.AHP.Consortium.Domain/QueryHandlers/GetOrganisationConsortiumQueryHandler.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/QueryHandlers/GetOrganisationConsortiumQueryHandler.cs
@@ -1,0 +1,27 @@
+using System.Collections.ObjectModel;
+using HE.Investments.AHP.Consortium.Contract;
+using HE.Investments.AHP.Consortium.Contract.Queries;
+using HE.Investments.AHP.Consortium.Domain.Repositories;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Extensions;
+using MediatR;
+
+namespace HE.Investments.AHP.Consortium.Domain.QueryHandlers;
+
+public class GetOrganisationConsortiumQueryHandler(IConsortiumRepository repository)
+    : IRequestHandler<GetOrganisationConsortiumQuery, ConsortiumBasicDetails?>
+{
+    public async Task<ConsortiumBasicDetails?> Handle(GetOrganisationConsortiumQuery request, CancellationToken cancellationToken)
+    {
+        var consortia = await repository.GetConsortiumsListByMemberId(request.OrganisationId, cancellationToken);
+        var consortium = consortia.FirstOrDefault(x => x.Programme.Id == request.ProgrammeId);
+
+        return consortium.IsProvided()
+            ? new ConsortiumBasicDetails(
+                consortium!.Id,
+                consortium.Programme.Id,
+                consortium.LeadPartner.Id,
+                new ReadOnlyCollection<OrganisationId>(consortium.ActiveMembers.Select(x => x.Id).ToList()))
+            : null;
+    }
+}

--- a/src/HE.Investments.Account.Shared/AccountUserContext.cs
+++ b/src/HE.Investments.Account.Shared/AccountUserContext.cs
@@ -4,6 +4,7 @@ using HE.Investments.Account.Shared.User;
 using HE.Investments.Account.Shared.User.Entities;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Contract.Exceptions;
+using HE.Investments.Common.Infrastructure.Cache;
 using HE.Investments.Common.Infrastructure.Cache.Interfaces;
 using HE.Investments.Common.User;
 
@@ -66,36 +67,5 @@ public class AccountUserContext : IAccountUserContext
     {
         var userProfile = await _userProfile.GetAsync();
         return userProfile!;
-    }
-
-    private sealed class CachedEntity<TEntity>
-        where TEntity : class
-    {
-        private readonly ICacheService _cacheService;
-
-        private readonly string _cacheKey;
-
-        private readonly Func<Task<TEntity>> _loadEntity;
-
-        private TEntity? _entity;
-
-        public CachedEntity(ICacheService cacheService, string cacheKey, Func<Task<TEntity>> loadEntity)
-        {
-            _cacheKey = cacheKey;
-            _loadEntity = loadEntity;
-            _cacheService = cacheService;
-            _entity = null;
-        }
-
-        public async ValueTask<TEntity?> GetAsync()
-        {
-            return _entity ??= await _cacheService.GetValueAsync(_cacheKey, _loadEntity);
-        }
-
-        public async Task InvalidateAsync()
-        {
-            _entity = await _loadEntity();
-            await _cacheService.SetValueAsync(_cacheKey, _entity);
-        }
     }
 }

--- a/src/HE.Investments.Account.Shared/IAccountUserContext.cs
+++ b/src/HE.Investments.Account.Shared/IAccountUserContext.cs
@@ -1,24 +1,7 @@
 using HE.Investments.Account.Shared.User;
-using HE.Investments.Account.Shared.User.Entities;
-using HE.Investments.Common.Contract;
 
 namespace HE.Investments.Account.Shared;
 
-public interface IAccountUserContext
+public interface IAccountUserContext : IUserAccountContext<UserAccount>
 {
-    bool IsLogged { get; }
-
-    UserGlobalId UserGlobalId { get; }
-
-    string Email { get; }
-
-    Task<UserAccount> GetSelectedAccount();
-
-    Task<UserProfileDetails> GetProfileDetails();
-
-    Task RefreshUserData();
-
-    Task<bool> IsProfileCompleted();
-
-    Task<bool> IsLinkedWithOrganisation();
 }

--- a/src/HE.Investments.Account.Shared/IUserAccountContext.cs
+++ b/src/HE.Investments.Account.Shared/IUserAccountContext.cs
@@ -1,0 +1,25 @@
+using HE.Investments.Account.Shared.User;
+using HE.Investments.Account.Shared.User.Entities;
+using HE.Investments.Common.Contract;
+
+namespace HE.Investments.Account.Shared;
+
+public interface IUserAccountContext<TUserAccount>
+    where TUserAccount : UserAccount
+{
+    bool IsLogged { get; }
+
+    UserGlobalId UserGlobalId { get; }
+
+    string Email { get; }
+
+    Task<TUserAccount> GetSelectedAccount();
+
+    Task<UserProfileDetails> GetProfileDetails();
+
+    Task RefreshUserData();
+
+    Task<bool> IsProfileCompleted();
+
+    Task<bool> IsLinkedWithOrganisation();
+}

--- a/src/HE.Investments.Common.Contract/FileId.cs
+++ b/src/HE.Investments.Common.Contract/FileId.cs
@@ -2,8 +2,8 @@ namespace HE.Investments.Common.Contract;
 
 public record FileId : StringIdValueObject
 {
-    private FileId(string id)
-        : base(id)
+    private FileId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investments.Common.Contract/ShortGuid.cs
+++ b/src/HE.Investments.Common.Contract/ShortGuid.cs
@@ -33,27 +33,30 @@ public class ShortGuid
 
     private static Guid Decode(string value)
     {
-        if (Guid.TryParse(value, out _))
+        if (TryDecode(value, out var guid))
         {
-            return new Guid(value);
+            return guid;
         }
 
-        value = value.Replace("_", "/").Replace("-", "+");
-        var buffer = Convert.FromBase64String(value + "==");
-        return new Guid(buffer);
+        throw new FormatException($"Invalid encoded short guid {value}");
     }
 
     private static bool TryDecode(string value, out Guid guid)
     {
-        try
+        if (Guid.TryParse(value, out guid))
         {
-            guid = Decode(value);
             return true;
         }
-        catch (FormatException)
+
+        value = value.Replace("_", "/").Replace("-", "+");
+
+        var buffer = new Span<byte>(new byte[16]);
+        if (Convert.TryFromBase64String(value + "==", buffer, out _))
         {
-            guid = Guid.Empty;
-            return false;
+            guid = new Guid(buffer);
+            return true;
         }
+
+        return false;
     }
 }

--- a/src/HE.Investments.Common.Contract/StringIdValueObject.cs
+++ b/src/HE.Investments.Common.Contract/StringIdValueObject.cs
@@ -1,18 +1,18 @@
 namespace HE.Investments.Common.Contract;
 
-public record StringIdValueObject
+public abstract record StringIdValueObject
 {
-    public StringIdValueObject(string id)
+    protected StringIdValueObject(string value)
     {
-        if (string.IsNullOrWhiteSpace(id))
+        if (string.IsNullOrWhiteSpace(value))
         {
             throw new ArgumentException("Cannot create id for empty value");
         }
 
-        Value = id;
+        Value = value;
     }
 
-    public StringIdValueObject()
+    protected StringIdValueObject()
     {
         Value = string.Empty;
     }
@@ -26,6 +26,26 @@ public record StringIdValueObject
     public static string FromGuidToShortGuidAsString(Guid value) => ShortGuid.FromGuid(value).Value;
 
     public static string FromStringToShortGuidAsString(string value) => ShortGuid.FromString(value).Value;
+
+    public virtual bool Equals(StringIdValueObject? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return ShortGuid.TryToGuidAsString(Value) == ShortGuid.TryToGuidAsString(other.Value);
+    }
+
+    public override int GetHashCode()
+    {
+        return ShortGuid.TryToGuidAsString(Value).GetHashCode();
+    }
 
     public override string ToString()
     {

--- a/src/HE.Investments.Common.Tests/Domain/ValueObjects/OrganisationIdTests.cs
+++ b/src/HE.Investments.Common.Tests/Domain/ValueObjects/OrganisationIdTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using HE.Investments.Common.Contract;
+using Xunit;
+
+namespace HE.Investments.Common.Tests.Domain.ValueObjects;
+
+public class OrganisationIdTests
+{
+    [Theory]
+    [InlineData("0fa56497-4912-4d58-a15f-0f60c882dbfd", "0fa56497-4912-4d58-a15f-0f60c882dbfd")]
+    [InlineData("l2SlDxJJWE2hXw9gyILb_Q", "l2SlDxJJWE2hXw9gyILb_Q")]
+    [InlineData("0fa56497-4912-4d58-a15f-0f60c882dbfd", "l2SlDxJJWE2hXw9gyILb_Q")]
+    [InlineData("l2SlDxJJWE2hXw9gyILb_Q", "0fa56497-4912-4d58-a15f-0f60c882dbfd")]
+    public void ShouldReturnTrue_WhenComparingTheSameOrganisationId(string first, string second)
+    {
+        // given
+        var organisation1 = new OrganisationId(first);
+        var organisation2 = new OrganisationId(second);
+
+        // when
+        var result = organisation1 == organisation2;
+
+        // then
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldReturnFalse_WhenComparingDifferentEncodedGuids()
+    {
+        // given
+        var organisation1 = OrganisationId.From(Guid.NewGuid());
+        var organisation2 = OrganisationId.From(Guid.NewGuid());
+
+        // when
+        var result = organisation1 == organisation2;
+
+        // then
+        result.Should().BeFalse();
+    }
+}

--- a/src/HE.Investments.Common/Infrastructure/Cache/CachedEntity.cs
+++ b/src/HE.Investments.Common/Infrastructure/Cache/CachedEntity.cs
@@ -1,0 +1,34 @@
+using HE.Investments.Common.Infrastructure.Cache.Interfaces;
+
+namespace HE.Investments.Common.Infrastructure.Cache;
+
+public sealed class CachedEntity<TEntity>
+    where TEntity : class
+{
+    private readonly ICacheService _cacheService;
+
+    private readonly string _cacheKey;
+
+    private readonly Func<Task<TEntity>> _loadEntity;
+
+    private TEntity? _entity;
+
+    public CachedEntity(ICacheService cacheService, string cacheKey, Func<Task<TEntity>> loadEntity)
+    {
+        _cacheKey = cacheKey;
+        _loadEntity = loadEntity;
+        _cacheService = cacheService;
+        _entity = null;
+    }
+
+    public async ValueTask<TEntity?> GetAsync()
+    {
+        return _entity ??= await _cacheService.GetValueAsync(_cacheKey, _loadEntity);
+    }
+
+    public async Task InvalidateAsync()
+    {
+        _entity = await _loadEntity();
+        await _cacheService.SetValueAsync(_cacheKey, _entity);
+    }
+}

--- a/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorProjectId.cs
+++ b/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorProjectId.cs
@@ -5,8 +5,8 @@ namespace HE.Investments.FrontDoor.Shared.Project;
 
 public record FrontDoorProjectId : StringIdValueObject
 {
-    public FrontDoorProjectId(string id)
-        : base(id)
+    public FrontDoorProjectId(string value)
+        : base(value)
     {
     }
 

--- a/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorSiteId.cs
+++ b/src/HE.Investments.FrontDoor.Shared/Project/FrontDoorSiteId.cs
@@ -5,8 +5,8 @@ namespace HE.Investments.FrontDoor.Shared.Project;
 
 public record FrontDoorSiteId : StringIdValueObject
 {
-    public FrontDoorSiteId(string id)
-        : base(id)
+    public FrontDoorSiteId(string value)
+        : base(value)
     {
     }
 


### PR DESCRIPTION
### 🛠 Changes being made

Created AHP user context:
- uses existing UserAccountContext which is cached in memory (per request) and in redis
- enriches information with Consortium details, cached the same way as user account

Additional changes:
- renamed value objects constructor parameter to match property name - fix for json serialization
- fixed comparison of StringIdValueObject when one value is encoded and other not
- improved short guid decoding - replaced exception catching with tryconvert

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you added some unit tests?
