### PR TITLE
AB#74674 Application partners - domain + wire up with CRM.

### DIFF
--- a/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideApplicationPartnersConfirmationCommand.cs
+++ b/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideApplicationPartnersConfirmationCommand.cs
@@ -1,0 +1,7 @@
+using HE.Investment.AHP.Contract.Application;
+using HE.Investments.Common.Contract.Validators;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.Scheme.Commands;
+
+public record ProvideApplicationPartnersConfirmationCommand(AhpApplicationId ApplicationId, bool? IsConfirmed) : IRequest<OperationResult>, IUpdateSchemeCommand;

--- a/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideDevelopingPartnerCommand.cs
+++ b/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideDevelopingPartnerCommand.cs
@@ -1,0 +1,8 @@
+using HE.Investment.AHP.Contract.Application;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Validators;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.Scheme.Commands;
+
+public record ProvideDevelopingPartnerCommand(AhpApplicationId ApplicationId, OrganisationId OrganisationId) : IRequest<OperationResult>, IUpdateSchemeCommand;

--- a/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideOwnerOfTheHomesCommand.cs
+++ b/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideOwnerOfTheHomesCommand.cs
@@ -1,0 +1,8 @@
+using HE.Investment.AHP.Contract.Application;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Validators;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.Scheme.Commands;
+
+public record ProvideOwnerOfTheHomesCommand(AhpApplicationId ApplicationId, OrganisationId OrganisationId) : IRequest<OperationResult>, IUpdateSchemeCommand;

--- a/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideOwnerOfTheLandCommand.cs
+++ b/src/HE.Investment.AHP.Contract/Scheme/Commands/ProvideOwnerOfTheLandCommand.cs
@@ -1,0 +1,8 @@
+using HE.Investment.AHP.Contract.Application;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Validators;
+using MediatR;
+
+namespace HE.Investment.AHP.Contract.Scheme.Commands;
+
+public record ProvideOwnerOfTheLandCommand(AhpApplicationId ApplicationId, OrganisationId OrganisationId) : IRequest<OperationResult>, IUpdateSchemeCommand;

--- a/src/HE.Investment.AHP.Domain.Tests/Application/Entities/ApplicationEntityTests/ApplicationEntityBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Application/Entities/ApplicationEntityTests/ApplicationEntityBuilder.cs
@@ -3,6 +3,7 @@ using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Domain.Application.Entities;
 using HE.Investment.AHP.Domain.Application.Factories;
 using HE.Investment.AHP.Domain.Application.ValueObjects;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
 using HE.Investments.Account.Shared.User;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Tests.TestData;
@@ -83,6 +84,7 @@ public class ApplicationEntityBuilder
             _name,
             _status,
             new ApplicationTenure(Tenure.AffordableRent),
+            ApplicationPartners.ConfirmedPartner(OrganisationId.From("cd7e3fb6-bff0-43ee-b65c-54db77d81f4c")),
             new ApplicationStateFactory(_userAccount, _previousStatus, _wasSubmitted),
             _reference,
             new ApplicationSections(_sections ?? []));

--- a/src/HE.Investment.AHP.Domain.Tests/Delivery/Entities/TestDataBuilders/OrganisationBasicInfoBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Delivery/Entities/TestDataBuilders/OrganisationBasicInfoBuilder.cs
@@ -1,22 +1,21 @@
 using HE.Investments.Account.Shared;
 using HE.Investments.Common.Contract;
+using HE.Investments.TestsUtils.TestFramework;
 
 namespace HE.Investment.AHP.Domain.Tests.Delivery.Entities.TestDataBuilders;
 
-public class OrganisationBasicInfoBuilder
+public class OrganisationBasicInfoBuilder : TestObjectBuilder<OrganisationBasicInfoBuilder, OrganisationBasicInfo>
 {
-    private readonly OrganisationId _organisationId = new("00000000-0000-0000-0000-000000000001");
-    private bool _isUnregisteredBody;
-
-    public OrganisationBasicInfoBuilder WithUnregisteredBody()
+    public OrganisationBasicInfoBuilder()
+        : base(new OrganisationBasicInfo(new("00000000-0000-0000-0000-000000000001"), "AccountOne", "1234", "London", false))
     {
-        _isUnregisteredBody = true;
-
-        return this;
     }
 
-    public OrganisationBasicInfo Build()
-    {
-        return new OrganisationBasicInfo(_organisationId, "AccountOne", "1234", "London", _isUnregisteredBody);
-    }
+    protected override OrganisationBasicInfoBuilder Builder => this;
+
+    public OrganisationBasicInfoBuilder WithUnregisteredBody() => SetProperty(x => x.IsUnregisteredBody, true);
+
+    public OrganisationBasicInfoBuilder WithId(OrganisationId value) => SetProperty(x => x.OrganisationId, value);
+
+    public OrganisationBasicInfoBuilder WithName(string value) => SetProperty(x => x.RegisteredCompanyName, value);
 }

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/TestObjectBuilders/ApplicationPartnersBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/TestObjectBuilders/ApplicationPartnersBuilder.cs
@@ -1,0 +1,31 @@
+extern alias Org;
+
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+using HE.Investments.TestsUtils.TestFramework;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.TestObjectBuilders;
+
+public class ApplicationPartnersBuilder : TestObjectBuilder<ApplicationPartnersBuilder, ApplicationPartners>
+{
+    private ApplicationPartnersBuilder()
+        : base(new ApplicationPartners(
+            InvestmentsOrganisationTestData.JjCompany,
+            InvestmentsOrganisationTestData.JjCompany,
+            InvestmentsOrganisationTestData.JjCompany))
+    {
+    }
+
+    protected override ApplicationPartnersBuilder Builder => this;
+
+    public static ApplicationPartnersBuilder New() => new();
+
+    public ApplicationPartnersBuilder WithDevelopingPartner(InvestmentsOrganisation value) => SetProperty(x => x.DevelopingPartner, value);
+
+    public ApplicationPartnersBuilder WithOwnerOfTheLand(InvestmentsOrganisation value) => SetProperty(x => x.OwnerOfTheLand, value);
+
+    public ApplicationPartnersBuilder WithOwnerOfTheHomes(InvestmentsOrganisation value) => SetProperty(x => x.OwnerOfTheHomes, value);
+
+    public ApplicationPartnersBuilder WithConfirmation(bool? value) => SetProperty(x => x.IsConfirmed, value);
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/TestObjectBuilders/SchemeEntityBuilder.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/TestObjectBuilders/SchemeEntityBuilder.cs
@@ -14,8 +14,9 @@ public class SchemeEntityBuilder
     {
         _item = new SchemeEntity(
             ApplicationBasicInfoTestData.SharedOwnershipInDraftState,
-            SchemeFunding.Empty(),
             SectionStatus.NotStarted,
+            SchemeFunding.Empty(),
+            ApplicationPartners.ConfirmedPartner(OrganisationId.From("cd7e3fb6-bff0-43ee-b65c-54db77d81f4c")),
             new AffordabilityEvidence(string.Empty),
             new SalesRisk(null),
             new HousingNeeds(string.Empty, string.Empty),

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/ConfirmedPartnerTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/ConfirmedPartnerTests.cs
@@ -1,0 +1,43 @@
+extern alias Org;
+
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investment.AHP.Domain.Tests.Delivery.Entities.TestDataBuilders;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class ConfirmedPartnerTests
+{
+    [Fact]
+    public void ShouldCreateConfirmedApplicationPartners_WhenFullOrganisationIsProvided()
+    {
+        // given
+        var organisation = new OrganisationBasicInfoBuilder()
+            .WithId(InvestmentsOrganisationTestData.CactusDevelopments.Id)
+            .WithName(InvestmentsOrganisationTestData.CactusDevelopments.Name)
+            .Build();
+
+        // when
+        var result = ApplicationPartners.ConfirmedPartner(organisation);
+
+        // then
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.IsConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCreateConfirmedApplicationPartners_WhenOnlyOrganisationIdIsProvided()
+    {
+        // given & when
+        var result = ApplicationPartners.ConfirmedPartner(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+
+        // then
+        result.DevelopingPartner.Id.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+        result.OwnerOfTheLand.Id.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+        result.OwnerOfTheHomes.Id.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+        result.IsConfirmed.Should().BeTrue();
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/FromSitePartnersTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/FromSitePartnersTests.cs
@@ -1,0 +1,67 @@
+extern alias Org;
+
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+using HE.Investment.AHP.Domain.Tests.Site.TestDataBuilders;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Exceptions;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class FromSitePartnersTests
+{
+    [Theory]
+    [InlineData("a", "b", null)]
+    [InlineData("a", null, "c")]
+    [InlineData(null, "b", "c")]
+    [InlineData(null, null, null)]
+    public void ShouldThrowException_WhenSitePartnersIsNotCompleted(string? developingPartner, string? ownerOfTheLand, string? ownerOfTheHomes)
+    {
+        // given
+        var builder = SitePartnersBuilder.New();
+        if (developingPartner != null)
+        {
+            builder = builder.WithDevelopingPartner(new InvestmentsOrganisation(new OrganisationId(developingPartner), developingPartner));
+        }
+
+        if (ownerOfTheLand != null)
+        {
+            builder = builder.WithOwnerOfTheLand(new InvestmentsOrganisation(new OrganisationId(ownerOfTheLand), ownerOfTheLand));
+        }
+
+        if (ownerOfTheHomes != null)
+        {
+            builder = builder.WithOwnerOfTheHomes(new InvestmentsOrganisation(new OrganisationId(ownerOfTheHomes), ownerOfTheHomes));
+        }
+
+        var sitePartners = builder.Build();
+
+        // when
+        var create = () => ApplicationPartners.FromSitePartners(sitePartners);
+
+        // then
+        create.Should().Throw<DomainValidationException>();
+    }
+
+    [Fact]
+    public void ShouldCreateNotConfirmedApplicationPartners_WhenSitePartnersIsCompleted()
+    {
+        // given
+        var sitePartners = SitePartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.CactusDevelopments)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.MoralesEntertainment)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .Build();
+
+        // when
+        var result = ApplicationPartners.FromSitePartners(sitePartners);
+
+        // then
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.MoralesEntertainment);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeNull();
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/IsAnsweredTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/IsAnsweredTests.cs
@@ -1,0 +1,41 @@
+extern alias Org;
+
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Tests.Scheme.TestObjectBuilders;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class IsAnsweredTests
+{
+    [Fact]
+    public void ShouldReturnTrue_WhenApplicationPartnersAreConfirmed()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.IsAnswered();
+
+        // then
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void ShouldReturnFalse_WhenApplicationPartnersAreNotConfirmed(bool? isConfirmed)
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithConfirmation(isConfirmed)
+            .Build();
+
+        // when
+        var result = testCandidate.IsAnswered();
+
+        // then
+        result.Should().BeFalse();
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithDevelopingPartnerTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithDevelopingPartnerTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Tests.Scheme.TestObjectBuilders;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class WithDevelopingPartnerTests
+{
+    [Fact]
+    public void ShouldNotChangeAnything_WhenDevelopingPartnerIsTheSame()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany);
+
+        // then
+        result.Should().Be(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldResetConfirmation_WhenDevelopingPartnerChanged()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithDevelopingPartner(InvestmentsOrganisationTestData.CactusDevelopments);
+
+        // then
+        result.Should().NotBe(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeNull();
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheHomesTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheHomesTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Tests.Scheme.TestObjectBuilders;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class WithOwnerOfTheHomesTests
+{
+    [Fact]
+    public void ShouldNotChangeAnything_WhenOwnerOfTheHomesIsTheSame()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany);
+
+        // then
+        result.Should().Be(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldResetConfirmation_WhenOwnerOfTheHomesChanged()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithOwnerOfTheHomes(InvestmentsOrganisationTestData.CactusDevelopments);
+
+        // then
+        result.Should().NotBe(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.IsConfirmed.Should().BeNull();
+    }
+}

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheLandTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheLandTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using HE.Investment.AHP.Domain.Tests.Scheme.TestObjectBuilders;
+using HE.Investment.AHP.Domain.Tests.Site.TestData;
+
+namespace HE.Investment.AHP.Domain.Tests.Scheme.ValueObjects.ApplicationPartnersTests;
+
+public class WithOwnerOfTheLandTests
+{
+    [Fact]
+    public void ShouldNotChangeAnything_WhenOwnerOfTheLandIsTheSame()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany);
+
+        // then
+        result.Should().Be(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldResetConfirmation_WhenOwnerOfTheLandChanged()
+    {
+        // given
+        var testCandidate = ApplicationPartnersBuilder.New()
+            .WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany)
+            .WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany)
+            .WithConfirmation(true)
+            .Build();
+
+        // when
+        var result = testCandidate.WithOwnerOfTheLand(InvestmentsOrganisationTestData.CactusDevelopments);
+
+        // then
+        result.Should().NotBe(testCandidate);
+        result.DevelopingPartner.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.OwnerOfTheLand.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments);
+        result.OwnerOfTheHomes.Should().Be(InvestmentsOrganisationTestData.JjCompany);
+        result.IsConfirmed.Should().BeNull();
+    }
+}

--- a/src/HE.Investment.AHP.Domain/Application/CommandHandlers/CreateApplicationCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/Application/CommandHandlers/CreateApplicationCommandHandler.cs
@@ -1,10 +1,13 @@
 using HE.Investment.AHP.Contract.Application;
 using HE.Investment.AHP.Contract.Application.Commands;
+using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Domain.Application.Entities;
 using HE.Investment.AHP.Domain.Application.Factories;
 using HE.Investment.AHP.Domain.Application.Repositories;
 using HE.Investment.AHP.Domain.Application.ValueObjects;
-using HE.Investments.Account.Shared;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investment.AHP.Domain.Site.Repositories;
+using HE.Investment.AHP.Domain.UserContext;
 using HE.Investments.Common.Contract.Exceptions;
 using HE.Investments.Common.Contract.Validators;
 using MediatR;
@@ -14,26 +17,47 @@ namespace HE.Investment.AHP.Domain.Application.CommandHandlers;
 public class CreateApplicationCommandHandler : IRequestHandler<CreateApplicationCommand, OperationResult<AhpApplicationId>>
 {
     private readonly IApplicationRepository _repository;
-    private readonly IAccountUserContext _accountUserContext;
 
-    public CreateApplicationCommandHandler(IApplicationRepository repository, IAccountUserContext accountUserContext)
+    private readonly ISiteRepository _siteRepository;
+
+    private readonly IAhpUserContext _ahpUserContext;
+
+    public CreateApplicationCommandHandler(IApplicationRepository repository, ISiteRepository siteRepository, IAhpUserContext ahpUserContext)
     {
         _repository = repository;
-        _accountUserContext = accountUserContext;
+        _siteRepository = siteRepository;
+        _ahpUserContext = ahpUserContext;
     }
 
     public async Task<OperationResult<AhpApplicationId>> Handle(CreateApplicationCommand request, CancellationToken cancellationToken)
     {
         var name = new ApplicationName(request.Name);
-        var account = await _accountUserContext.GetSelectedAccount();
+        var account = await _ahpUserContext.GetSelectedAccount();
         if (await _repository.IsNameExist(name, account.SelectedOrganisationId(), cancellationToken))
         {
             throw new FoundException("Name", "There is already an application with this name. Enter a different name");
         }
 
-        var applicationToCreate = ApplicationEntity.New(request.SiteId, name, new ApplicationTenure(request.Tenure), new ApplicationStateFactory(account));
+        var applicationPartners = await GetApplicationPartners(request.SiteId, account, cancellationToken);
+        var applicationToCreate = ApplicationEntity.New(
+            request.SiteId,
+            name,
+            new ApplicationTenure(request.Tenure),
+            applicationPartners,
+            new ApplicationStateFactory(account));
         var application = await _repository.Save(applicationToCreate, account.SelectedOrganisationId(), cancellationToken);
 
         return new OperationResult<AhpApplicationId>(application.Id);
+    }
+
+    private async Task<ApplicationPartners> GetApplicationPartners(SiteId siteId, AhpUserAccount userAccount, CancellationToken cancellationToken)
+    {
+        if (userAccount.Consortium.HasNoConsortium)
+        {
+            return ApplicationPartners.ConfirmedPartner(userAccount.SelectedOrganisation());
+        }
+
+        var site = await _siteRepository.GetSite(siteId, userAccount, cancellationToken);
+        return ApplicationPartners.FromSitePartners(site.SitePartners);
     }
 }

--- a/src/HE.Investment.AHP.Domain/Application/Crm/ApplicationCrmContext.cs
+++ b/src/HE.Investment.AHP.Domain/Application/Crm/ApplicationCrmContext.cs
@@ -74,7 +74,11 @@ public class ApplicationCrmContext : IApplicationCrmContext
                 nameof(invln_scheme.invln_grantsfromthelottery),
                 nameof(invln_scheme.invln_grantsfromotherpublicbodies),
                 nameof(invln_scheme.invln_programmelookup),
-                nameof(invln_scheme.invln_representationsandwarrantiesconfirmation))
+                nameof(invln_scheme.invln_representationsandwarrantiesconfirmation),
+                nameof(invln_scheme.invln_DevelopingPartner),
+                nameof(invln_scheme.invln_OwneroftheLand),
+                nameof(invln_scheme.invln_OwneroftheHomes),
+                nameof(invln_scheme.invln_partnerconfirmation))
             .ToLowerInvariant();
 
     private readonly ICrmService _service;

--- a/src/HE.Investment.AHP.Domain/Application/Entities/ApplicationEntity.cs
+++ b/src/HE.Investment.AHP.Domain/Application/Entities/ApplicationEntity.cs
@@ -3,6 +3,7 @@ using HE.Investment.AHP.Contract.Application.Events;
 using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Domain.Application.Factories;
 using HE.Investment.AHP.Domain.Application.ValueObjects;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Contract.Exceptions;
 using HE.Investments.Common.Contract.Validators;
@@ -26,6 +27,7 @@ public class ApplicationEntity : DomainEntity
         ApplicationName name,
         ApplicationStatus status,
         ApplicationTenure tenure,
+        ApplicationPartners applicationPartners,
         IApplicationStateFactory applicationStateFactory,
         ApplicationReferenceNumber? referenceNumber = null,
         ApplicationSections? sections = null,
@@ -39,6 +41,7 @@ public class ApplicationEntity : DomainEntity
         Status = status;
         ReferenceNumber = referenceNumber ?? new ApplicationReferenceNumber(null);
         Tenure = tenure;
+        ApplicationPartners = applicationPartners;
         LastModified = lastModified;
         LastSubmitted = lastSubmitted;
         Sections = sections ?? new ApplicationSections([]);
@@ -53,6 +56,8 @@ public class ApplicationEntity : DomainEntity
     public ApplicationName Name { get; private set; }
 
     public ApplicationStatus Status { get; private set; }
+
+    public ApplicationPartners ApplicationPartners { get; private set; }
 
     public IEnumerable<AhpApplicationOperation> AllowedOperations => _applicationState.AllowedOperations;
 
@@ -76,12 +81,18 @@ public class ApplicationEntity : DomainEntity
 
     public bool IsNew => Id.IsNew;
 
-    public static ApplicationEntity New(SiteId siteId, ApplicationName name, ApplicationTenure tenure, IApplicationStateFactory applicationStateFactory) => new(
+    public static ApplicationEntity New(
+        SiteId siteId,
+        ApplicationName name,
+        ApplicationTenure tenure,
+        ApplicationPartners applicationPartners,
+        IApplicationStateFactory applicationStateFactory) => new(
         siteId,
         AhpApplicationId.New(),
         name,
         ApplicationStatus.New,
         tenure,
+        applicationPartners,
         applicationStateFactory);
 
     public void SetId(AhpApplicationId newId)

--- a/src/HE.Investment.AHP.Domain/Application/Mappers/ApplicationPartnersMapper.cs
+++ b/src/HE.Investment.AHP.Domain/Application/Mappers/ApplicationPartnersMapper.cs
@@ -1,0 +1,30 @@
+extern alias Org;
+
+using HE.Common.IntegrationModel.PortalIntegrationModel;
+using HE.Investment.AHP.Domain.Scheme.ValueObjects;
+using HE.Investments.Common.Contract;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Application.Mappers;
+
+internal static class ApplicationPartnersMapper
+{
+    public static ApplicationPartners ToDomain(AhpApplicationDto dto)
+    {
+        if (string.IsNullOrEmpty(dto.developingPartnerId)
+            || string.IsNullOrEmpty(dto.ownerOfTheLandDuringDevelopmentId)
+            || string.IsNullOrEmpty(dto.ownerOfTheHomesAfterCompletionId))
+        {
+            return ApplicationPartners.ConfirmedPartner(OrganisationId.From(dto.organisationId));
+        }
+
+        return new ApplicationPartners(
+            MapPartner(dto.developingPartnerId, dto.developingPartnerName),
+            MapPartner(dto.ownerOfTheLandDuringDevelopmentId, dto.ownerOfTheLandDuringDevelopmentName),
+            MapPartner(dto.ownerOfTheHomesAfterCompletionId, dto.ownerOfTheHomesAfterCompletionName),
+            dto.applicationPartnerConfirmation);
+    }
+
+    private static InvestmentsOrganisation MapPartner(string organisationId, string organisationName) =>
+        new(OrganisationId.From(organisationId), organisationName);
+}

--- a/src/HE.Investment.AHP.Domain/Application/Repositories/ApplicationRepository.cs
+++ b/src/HE.Investment.AHP.Domain/Application/Repositories/ApplicationRepository.cs
@@ -5,6 +5,7 @@ using HE.Investment.AHP.Contract.Site;
 using HE.Investment.AHP.Domain.Application.Crm;
 using HE.Investment.AHP.Domain.Application.Entities;
 using HE.Investment.AHP.Domain.Application.Factories;
+using HE.Investment.AHP.Domain.Application.Mappers;
 using HE.Investment.AHP.Domain.Application.ValueObjects;
 using HE.Investment.AHP.Domain.Common;
 using HE.Investment.AHP.Domain.FinancialDetails.Mappers;
@@ -133,6 +134,9 @@ public class ApplicationRepository : IApplicationRepository
         dto.organisationId = organisationId.ToGuidAsString();
         dto.applicationStatus = AhpApplicationStatusMapper.MapToCrmStatus(application.Status);
         dto.siteId = application.SiteId.ToGuidAsString();
+        dto.developingPartnerId = application.ApplicationPartners.DevelopingPartner.Id.ToGuidAsString();
+        dto.ownerOfTheLandDuringDevelopmentId = application.ApplicationPartners.OwnerOfTheLand.Id.ToGuidAsString();
+        dto.ownerOfTheHomesAfterCompletionId = application.ApplicationPartners.OwnerOfTheHomes.Id.ToGuidAsString();
 
         var id = await _applicationCrmContext.Save(dto, organisationId.ToGuidAsString(), cancellationToken);
         if (application.Id.IsNew)
@@ -170,6 +174,7 @@ public class ApplicationRepository : IApplicationRepository
             new ApplicationName(application.name ?? "Unknown"),
             applicationStatus,
             ApplicationTenureMapper.ToDomain(application.tenure)!,
+            ApplicationPartnersMapper.ToDomain(application),
             new ApplicationStateFactory(userAccount, previousStatus, application.dateSubmitted.IsProvided()),
             new ApplicationReferenceNumber(application.referenceNumber),
             new ApplicationSections(

--- a/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideApplicationPartnersConfirmationCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideApplicationPartnersConfirmationCommandHandler.cs
@@ -1,0 +1,20 @@
+using HE.Investment.AHP.Contract.Scheme.Commands;
+using HE.Investment.AHP.Domain.Scheme.Entities;
+using HE.Investment.AHP.Domain.Scheme.Repositories;
+using HE.Investments.Account.Shared;
+
+namespace HE.Investment.AHP.Domain.Scheme.CommandHandlers;
+
+public sealed class ProvideApplicationPartnersConfirmationCommandHandler : UpdateSchemeCommandHandler<ProvideApplicationPartnersConfirmationCommand>
+{
+    public ProvideApplicationPartnersConfirmationCommandHandler(ISchemeRepository repository, IAccountUserContext accountUserContext)
+        : base(repository, accountUserContext, includeFiles: false)
+    {
+    }
+
+    protected override void Update(SchemeEntity scheme, ProvideApplicationPartnersConfirmationCommand request)
+    {
+        var applicationPartners = scheme.ApplicationPartners.WithConfirmation(request.IsConfirmed);
+        scheme.ProvideApplicationPartners(applicationPartners);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideDevelopingPartnerCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideDevelopingPartnerCommandHandler.cs
@@ -1,0 +1,23 @@
+extern alias Org;
+
+using HE.Investment.AHP.Contract.Scheme.Commands;
+using HE.Investment.AHP.Domain.Scheme.Entities;
+using HE.Investment.AHP.Domain.Scheme.Repositories;
+using HE.Investments.Account.Shared;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Scheme.CommandHandlers;
+
+public sealed class ProvideDevelopingPartnerCommandHandler : UpdateSchemeCommandHandler<ProvideDevelopingPartnerCommand>
+{
+    public ProvideDevelopingPartnerCommandHandler(ISchemeRepository repository, IAccountUserContext accountUserContext)
+        : base(repository, accountUserContext, includeFiles: false)
+    {
+    }
+
+    protected override void Update(SchemeEntity scheme, ProvideDevelopingPartnerCommand request)
+    {
+        var applicationPartners = scheme.ApplicationPartners.WithDevelopingPartner(new InvestmentsOrganisation(request.OrganisationId, string.Empty));
+        scheme.ProvideApplicationPartners(applicationPartners);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideOwnerOfTheHomesCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideOwnerOfTheHomesCommandHandler.cs
@@ -1,0 +1,23 @@
+extern alias Org;
+
+using HE.Investment.AHP.Contract.Scheme.Commands;
+using HE.Investment.AHP.Domain.Scheme.Entities;
+using HE.Investment.AHP.Domain.Scheme.Repositories;
+using HE.Investments.Account.Shared;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Scheme.CommandHandlers;
+
+public sealed class ProvideOwnerOfTheHomesCommandHandler : UpdateSchemeCommandHandler<ProvideOwnerOfTheHomesCommand>
+{
+    public ProvideOwnerOfTheHomesCommandHandler(ISchemeRepository repository, IAccountUserContext accountUserContext)
+        : base(repository, accountUserContext, includeFiles: false)
+    {
+    }
+
+    protected override void Update(SchemeEntity scheme, ProvideOwnerOfTheHomesCommand request)
+    {
+        var applicationPartners = scheme.ApplicationPartners.WithOwnerOfTheHomes(new InvestmentsOrganisation(request.OrganisationId, string.Empty));
+        scheme.ProvideApplicationPartners(applicationPartners);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideOwnerOfTheLandCommandHandler.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/CommandHandlers/ProvideOwnerOfTheLandCommandHandler.cs
@@ -1,0 +1,23 @@
+extern alias Org;
+
+using HE.Investment.AHP.Contract.Scheme.Commands;
+using HE.Investment.AHP.Domain.Scheme.Entities;
+using HE.Investment.AHP.Domain.Scheme.Repositories;
+using HE.Investments.Account.Shared;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Scheme.CommandHandlers;
+
+public sealed class ProvideOwnerOfTheLandCommandHandler : UpdateSchemeCommandHandler<ProvideOwnerOfTheLandCommand>
+{
+    public ProvideOwnerOfTheLandCommandHandler(ISchemeRepository repository, IAccountUserContext accountUserContext)
+        : base(repository, accountUserContext, includeFiles: false)
+    {
+    }
+
+    protected override void Update(SchemeEntity scheme, ProvideOwnerOfTheLandCommand request)
+    {
+        var applicationPartners = scheme.ApplicationPartners.WithOwnerOfTheLand(new InvestmentsOrganisation(request.OrganisationId, string.Empty));
+        scheme.ProvideApplicationPartners(applicationPartners);
+    }
+}

--- a/src/HE.Investment.AHP.Domain/Scheme/Entities/SchemeEntity.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/Entities/SchemeEntity.cs
@@ -13,8 +13,9 @@ public class SchemeEntity : DomainEntity
 
     public SchemeEntity(
         ApplicationBasicInfo application,
-        SchemeFunding funding,
         SectionStatus status,
+        SchemeFunding funding,
+        ApplicationPartners applicationPartners,
         AffordabilityEvidence affordabilityEvidence,
         SalesRisk salesRisk,
         HousingNeeds housingNeeds,
@@ -23,6 +24,7 @@ public class SchemeEntity : DomainEntity
         Status = status;
         Application = application;
         Funding = funding;
+        ApplicationPartners = applicationPartners;
         AffordabilityEvidence = affordabilityEvidence;
         SalesRisk = salesRisk;
         HousingNeeds = housingNeeds;
@@ -32,6 +34,8 @@ public class SchemeEntity : DomainEntity
     public ApplicationBasicInfo Application { get; }
 
     public SchemeFunding Funding { get; private set; }
+
+    public ApplicationPartners ApplicationPartners { get; private set; }
 
     public AffordabilityEvidence AffordabilityEvidence { get; private set; }
 
@@ -48,6 +52,11 @@ public class SchemeEntity : DomainEntity
     public void ProvideFunding(SchemeFunding funding)
     {
         Funding = _modificationTracker.Change(Funding, funding, SetInProgress, FundingHasChanged);
+    }
+
+    public void ProvideApplicationPartners(ApplicationPartners applicationPartners)
+    {
+        ApplicationPartners = _modificationTracker.Change(ApplicationPartners, applicationPartners, SetInProgress);
     }
 
     public void ChangeAffordabilityEvidence(AffordabilityEvidence affordabilityEvidence)

--- a/src/HE.Investment.AHP.Domain/Scheme/Repositories/SchemeRepository.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/Repositories/SchemeRepository.cs
@@ -1,6 +1,9 @@
+extern alias Org;
+
 using HE.Common.IntegrationModel.PortalIntegrationModel;
 using HE.Investment.AHP.Contract.Application;
 using HE.Investment.AHP.Domain.Application.Crm;
+using HE.Investment.AHP.Domain.Application.Mappers;
 using HE.Investment.AHP.Domain.Application.Repositories;
 using HE.Investment.AHP.Domain.Common;
 using HE.Investment.AHP.Domain.Documents.Services;
@@ -64,6 +67,9 @@ public class SchemeRepository : ISchemeRepository
         dto.schemeInformationSectionCompletionStatus = SectionStatusMapper.ToDto(entity.Status);
         dto.fundingRequested = entity.Funding.RequiredFunding;
         dto.noOfHomes = entity.Funding.HousesToDeliver;
+        dto.developingPartnerId = entity.ApplicationPartners.DevelopingPartner.Id.ToGuidAsString();
+        dto.ownerOfTheLandDuringDevelopmentId = entity.ApplicationPartners.OwnerOfTheLand.Id.ToGuidAsString();
+        dto.ownerOfTheHomesAfterCompletionId = entity.ApplicationPartners.OwnerOfTheHomes.Id.ToGuidAsString();
         dto.affordabilityEvidence = entity.AffordabilityEvidence.Evidence;
         dto.discussionsWithLocalStakeholders = entity.StakeholderDiscussions.StakeholderDiscussionsDetails.Report;
         dto.meetingLocalProrities = entity.HousingNeeds.MeetingLocalPriorities;
@@ -81,8 +87,9 @@ public class SchemeRepository : ISchemeRepository
     {
         return new SchemeEntity(
             applicationBasicInfo,
-            new SchemeFunding((int?)dto.fundingRequested, dto.noOfHomes),
             SectionStatusMapper.ToDomain(dto.schemeInformationSectionCompletionStatus, applicationBasicInfo.Status),
+            new SchemeFunding((int?)dto.fundingRequested, dto.noOfHomes),
+            ApplicationPartnersMapper.ToDomain(dto),
             new AffordabilityEvidence(dto.affordabilityEvidence),
             new SalesRisk(dto.sharedOwnershipSalesRisk),
             new HousingNeeds(dto.meetingLocalProrities, dto.meetingLocalHousingNeed),

--- a/src/HE.Investment.AHP.Domain/Scheme/ValueObjects/ApplicationPartners.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/ValueObjects/ApplicationPartners.cs
@@ -1,0 +1,88 @@
+extern alias Org;
+
+using HE.Investment.AHP.Domain.Site.ValueObjects;
+using HE.Investments.Account.Shared;
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Exceptions;
+using HE.Investments.Common.Domain;
+using Org::HE.Investments.Organisation.ValueObjects;
+
+namespace HE.Investment.AHP.Domain.Scheme.ValueObjects;
+
+public class ApplicationPartners : ValueObject, IQuestion
+{
+    public ApplicationPartners(
+        InvestmentsOrganisation developingPartner,
+        InvestmentsOrganisation ownerOfTheLand,
+        InvestmentsOrganisation ownerOfTheHomes,
+        bool? isConfirmed = null)
+    {
+        DevelopingPartner = developingPartner;
+        OwnerOfTheLand = ownerOfTheLand;
+        OwnerOfTheHomes = ownerOfTheHomes;
+        IsConfirmed = isConfirmed;
+    }
+
+    public InvestmentsOrganisation DevelopingPartner { get; }
+
+    public InvestmentsOrganisation OwnerOfTheLand { get; }
+
+    public InvestmentsOrganisation OwnerOfTheHomes { get; }
+
+    public bool? IsConfirmed { get; }
+
+    public static ApplicationPartners ConfirmedPartner(OrganisationBasicInfo organisation)
+    {
+        var partner = new InvestmentsOrganisation(organisation.OrganisationId, organisation.RegisteredCompanyName);
+
+        return new ApplicationPartners(partner, partner, partner, true);
+    }
+
+    public static ApplicationPartners ConfirmedPartner(OrganisationId organisationId)
+    {
+        return ConfirmedPartner(new OrganisationBasicInfo(organisationId, string.Empty, string.Empty, string.Empty, false));
+    }
+
+    public static ApplicationPartners FromSitePartners(SitePartners sitePartners)
+    {
+        if (!sitePartners.IsAnswered())
+        {
+            throw new DomainValidationException("Cannot create Application Partners because Site Partners section is not completed.");
+        }
+
+        return new ApplicationPartners(sitePartners.DevelopingPartner!, sitePartners.OwnerOfTheLand!, sitePartners.OwnerOfTheHomes!);
+    }
+
+    public ApplicationPartners WithDevelopingPartner(InvestmentsOrganisation developingPartner)
+    {
+        return new ApplicationPartners(developingPartner, OwnerOfTheLand, OwnerOfTheHomes, developingPartner == DevelopingPartner ? IsConfirmed : null);
+    }
+
+    public ApplicationPartners WithOwnerOfTheLand(InvestmentsOrganisation ownerOfTheLand)
+    {
+        return new ApplicationPartners(DevelopingPartner, ownerOfTheLand, OwnerOfTheHomes, ownerOfTheLand == OwnerOfTheLand ? IsConfirmed : null);
+    }
+
+    public ApplicationPartners WithOwnerOfTheHomes(InvestmentsOrganisation ownerOfTheHomes)
+    {
+        return new ApplicationPartners(DevelopingPartner, OwnerOfTheLand, ownerOfTheHomes, ownerOfTheHomes == OwnerOfTheHomes ? IsConfirmed : null);
+    }
+
+    public ApplicationPartners WithConfirmation(bool? isConfirmed)
+    {
+        return new ApplicationPartners(DevelopingPartner, OwnerOfTheLand, OwnerOfTheHomes, isConfirmed);
+    }
+
+    public bool IsAnswered()
+    {
+        return IsConfirmed == true;
+    }
+
+    protected override IEnumerable<object?> GetAtomicValues()
+    {
+        yield return DevelopingPartner.Id;
+        yield return OwnerOfTheLand.Id;
+        yield return OwnerOfTheHomes.Id;
+        yield return IsConfirmed;
+    }
+}

--- a/src/HE.Investment.AHP.WWW/Models/Site/Factories/SiteSummaryViewModelFactory.cs
+++ b/src/HE.Investment.AHP.WWW/Models/Site/Factories/SiteSummaryViewModelFactory.cs
@@ -42,10 +42,6 @@ public class SiteSummaryViewModelFactory : ISiteSummaryViewModelFactory
         {
             yield return new SectionSummaryViewModel("Consortium", CreateConsortiumSummary(siteDetails, CreateAction, isEditable));
         }
-        else if (organisation.IsUnregisteredBody)
-        {
-            yield return new SectionSummaryViewModel("URB", CreateUrbSummary(siteDetails, CreateAction, isEditable));
-        }
 
         yield return new SectionSummaryViewModel("Land details", CreateLandDetailsSummary(siteDetails, CreateAction, isEditable));
         yield return new SectionSummaryViewModel("Site use", CreateSiteUseSummary(siteDetails, CreateAction, isEditable));
@@ -249,18 +245,6 @@ public class SiteSummaryViewModelFactory : ISiteSummaryViewModelFactory
                 site.OwnerOfTheLand?.Name.ToOneElementList(),
                 createAction(nameof(Controller.OwnerOfTheLand)),
                 IsEditable: isEditable),
-            new(
-                "Owner of the homes",
-                site.OwnerOfTheHomes?.Name.ToOneElementList(),
-                createAction(nameof(Controller.OwnerOfTheHomes)),
-                IsEditable: isEditable),
-        ];
-    }
-
-    private static List<SectionSummaryItemModel> CreateUrbSummary(SiteModel site, CreateAction createAction, bool isEditable)
-    {
-        return
-        [
             new(
                 "Owner of the homes",
                 site.OwnerOfTheHomes?.Name.ToOneElementList(),

--- a/src/HE.Investments.AHP.Consortium.Domain.Tests/Entities/ConsortiumEntityTests/AddMemberTests.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain.Tests/Entities/ConsortiumEntityTests/AddMemberTests.cs
@@ -84,4 +84,28 @@ public class AddMemberTests
         testCandidate.PopJoinRequest().Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
         testCandidate.PopJoinRequest().Should().BeNull();
     }
+
+    [Fact]
+    public async Task ShouldAddPendingMember_WhenMemberWasPreviouslyInThisConsortium()
+    {
+        // given
+        var testCandidate = new ConsortiumEntityBuilder()
+            .WithLeadPartner(InvestmentsOrganisationTestData.JjCompany)
+            .WithMember(InvestmentsOrganisationTestData.CactusDevelopments, ConsortiumMemberStatus.Inactive)
+            .Build();
+        var isPartOfConsortium = IsPartOfConsortiumBuilder.New().IsNotPartOfConsortium().Build();
+
+        // when
+        await testCandidate.AddMember(InvestmentsOrganisationTestData.CactusDevelopments, isPartOfConsortium, CancellationToken.None);
+
+        // then
+        var member = testCandidate.Members.Should().HaveCount(1).And.Subject.Single();
+
+        member.Id.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+        member.OrganisationName.Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Name);
+        member.Status.Should().Be(ConsortiumMemberStatus.PendingAddition);
+
+        testCandidate.PopJoinRequest().Should().Be(InvestmentsOrganisationTestData.CactusDevelopments.Id);
+        testCandidate.PopJoinRequest().Should().BeNull();
+    }
 }

--- a/src/HE.Investments.AHP.Consortium.Domain.Tests/TestObjectBuilders/ConsortiumEntityBuilder.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain.Tests/TestObjectBuilders/ConsortiumEntityBuilder.cs
@@ -32,7 +32,12 @@ public class ConsortiumEntityBuilder : TestObjectBuilder<ConsortiumEntityBuilder
 
     public ConsortiumEntityBuilder WithActiveMember(InvestmentsOrganisation organisation)
     {
-        List<ConsortiumMember> members = [.. Item.Members, new ConsortiumMember(organisation.Id, organisation.Name, ConsortiumMemberStatus.Active)];
+        return WithMember(organisation, ConsortiumMemberStatus.Active);
+    }
+
+    public ConsortiumEntityBuilder WithMember(InvestmentsOrganisation organisation, ConsortiumMemberStatus status)
+    {
+        List<ConsortiumMember> members = [.. Item.Members, new ConsortiumMember(organisation.Id, organisation.Name, status)];
         PrivatePropertySetter.SetPrivateField(Item, "_members", members);
 
         return this;

--- a/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
@@ -40,7 +40,7 @@ public class ConsortiumEntity : IConsortiumEntity
 
     public IEnumerable<ConsortiumMember> ActiveMembers => _members.Where(x => x.Status is ConsortiumMemberStatus.Active);
 
-    public IEnumerable<ConsortiumMember> Members => _members;
+    public IEnumerable<ConsortiumMember> Members => _members.Where(x => x.Status != ConsortiumMemberStatus.Inactive);
 
     public static async Task<ConsortiumEntity> New(ProgrammeSlim programme, ConsortiumMember leadPartner, IIsPartOfConsortium isPartOfConsortium)
     {
@@ -134,7 +134,7 @@ public class ConsortiumEntity : IConsortiumEntity
         IIsPartOfConsortium isPartOfConsortium,
         CancellationToken cancellationToken)
     {
-        if (organisation.Id == LeadPartner.Id || _members.Exists(x => x.Id == organisation.Id))
+        if (organisation.Id == LeadPartner.Id || Members.Any(x => x.Id == organisation.Id))
         {
             return true;
         }
@@ -142,6 +142,6 @@ public class ConsortiumEntity : IConsortiumEntity
         return await isPartOfConsortium.IsPartOfConsortiumForProgramme(Programme.Id, organisation.Id, cancellationToken);
     }
 
-    private ConsortiumMember GetMember(OrganisationId organisationId) => _members.SingleOrDefault(x => x.Id == organisationId) ??
+    private ConsortiumMember GetMember(OrganisationId organisationId) => Members.SingleOrDefault(x => x.Id == organisationId) ??
                                                                          throw new NotFoundException(nameof(ConsortiumMember), organisationId);
 }


### PR DESCRIPTION
### 🛠 Changes being made

Create domain part of Application Partners:
- Set Partners as current Organisation when Organisation is not part of a Consortium.
- Copy Partners from Site, when Organisation is part of a Consortium.
- Added Partners to Application and Scheme domain entities.
- Created commands/command handers for providing Application Partners and confirmation.
- Wire up with CRM.

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you added some unit tests?