### PR TITLE
AB#97105 Completed site should be readonly

### DIFF
--- a/src/HE.Investment.AHP.Contract/Site/SiteModel.cs
+++ b/src/HE.Investment.AHP.Contract/Site/SiteModel.cs
@@ -49,4 +49,6 @@ public class SiteModel
     public OrganisationDetails? OwnerOfTheLand { get; set; }
 
     public OrganisationDetails? OwnerOfTheHomes { get; set; }
+
+    public bool IsReadOnly => Status == SiteStatus.Completed;
 }

--- a/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
+++ b/src/HE.Investment.AHP.WWW/Controllers/SiteController.cs
@@ -1007,7 +1007,9 @@ public class SiteController : WorkflowController<SiteWorkflowState>
         SiteModel? siteModel = null;
         var siteId = Request.GetRouteValue("siteId")
                      ?? routeData?.GetPropertyValue<string>("siteId")
+                     ?? Request.Query.FirstOrDefault(queryParam => queryParam.Key == "siteId").Value.FirstOrDefault()
                      ?? string.Empty;
+
         if (siteId.IsNotNullOrEmpty())
         {
             siteModel = await _mediator.Send(new GetSiteQuery(siteId));
@@ -1080,7 +1082,7 @@ public class SiteController : WorkflowController<SiteWorkflowState>
     {
         var siteId = this.GetSiteIdFromRoute();
         var siteDetails = await GetSiteDetails(siteId.Value, cancellationToken);
-        var isEditable = await _accountAccessContext.CanEditApplication();
+        var isEditable = await _accountAccessContext.CanEditApplication() && siteDetails.Status != SiteStatus.Completed;
         var userAccount = await _accountUserContext.GetSelectedAccount();
         var sections = _siteSummaryViewModelFactory.CreateSiteSummary(siteDetails, userAccount.SelectedOrganisation(), Url, isEditable, useWorkflowRedirection);
 

--- a/src/HE.Investment.AHP.WWW/Workflows/SiteWorkflow.cs
+++ b/src/HE.Investment.AHP.WWW/Workflows/SiteWorkflow.cs
@@ -19,7 +19,7 @@ public class SiteWorkflow : EncodedStateRouting<SiteWorkflowState>
 
     public override bool CanBeAccessed(SiteWorkflowState state, bool? isReadOnlyMode = null)
     {
-        if (isReadOnlyMode == true)
+        if (isReadOnlyMode ?? _siteModel?.IsReadOnly == true)
         {
             return state == SiteWorkflowState.CheckAnswers;
         }

--- a/src/HE.Investments.AHP.IntegrationTests/FillSite/Order01StartAhpSite.cs
+++ b/src/HE.Investments.AHP.IntegrationTests/FillSite/Order01StartAhpSite.cs
@@ -577,10 +577,26 @@ public class Order01StartAhpSite : AhpIntegrationTest
         var siteListPage = await TestQuestionPage(
             SitePagesUrl.SiteCheckAnswers(SiteData.SiteId),
             SitePageTitles.CheckAnswers,
-            SitePagesUrl.SiteList,
+            "sites",
             (nameof(IsSectionCompleted), IsSectionCompleted.Yes.ToString()));
 
         siteListPage.HasTitle(SitePageTitles.SiteList)
             .HasLinkWithHref(SitePagesUrl.SiteDetails(SiteData.SiteId), out _);
+    }
+
+    [Fact(Skip = AhpConfig.SkipTest)]
+    [Order(39)]
+    public async Task Order39_SiteIsNotEditableAfterCompletion()
+    {
+        var checkAnswersPage = await GetCurrentPage(SitePagesUrl.SiteCheckAnswers(SiteData.SiteId));
+
+        var summaryItems = checkAnswersPage.GetSummaryListItems();
+        foreach (var item in summaryItems)
+        {
+            item.Value.ChangeAnswerLink.Should().BeNull();
+        }
+
+        var result = await TestClient.NavigateTo(SitePagesUrl.SiteName + "?siteId=" + SiteData.SiteId);
+        result.Title.Should().Be("Page not found");
     }
 }


### PR DESCRIPTION
### 🛠 Changes being made

For sites having status "Completed" removed "Change" buttons on check summary page and made sure they are not editable by manual siteId injection.

### 📸 Screenshots (optional)

Insert some screenshots if you made UI changes.

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [ ] Have you added some unit tests?
- [x] Have you added some integration tests?
- [ ] Have you checked WCAG (included screenshot)
