### PR TITLE
AB#74674 Fix consortium cache.

### DIFF
--- a/src/HE.Investment.AHP.Domain/UserContext/AhpCacheKeys.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/AhpCacheKeys.cs
@@ -1,0 +1,8 @@
+using HE.Investments.Common.Contract;
+
+namespace HE.Investment.AHP.Domain.UserContext;
+
+internal static class AhpCacheKeys
+{
+    public static string OrganisationConsortium(OrganisationId organisationId) => $"ahp-consortium-{organisationId}";
+}

--- a/src/HE.Investment.AHP.Domain/UserContext/AhpUserContext.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/AhpUserContext.cs
@@ -67,7 +67,7 @@ internal sealed class AhpUserContext(
         {
             consortiumCachedEntity = _consortia[organisationId!] = new CachedEntity<AhpConsortiumBasicInfo>(
                 cacheService,
-                $"ahp-consortium-{organisationId}",
+                AhpCacheKeys.OrganisationConsortium(organisationId!),
                 async () => await GetAhpConsortiumInfo(organisationId!));
         }
 

--- a/src/HE.Investment.AHP.Domain/UserContext/EventHandlers/InvalidateConsortiumCacheEventHandler.cs
+++ b/src/HE.Investment.AHP.Domain/UserContext/EventHandlers/InvalidateConsortiumCacheEventHandler.cs
@@ -1,0 +1,20 @@
+using HE.Investments.AHP.Consortium.Contract.Events;
+using HE.Investments.Common.Infrastructure.Cache.Interfaces;
+using HE.Investments.Common.Infrastructure.Events;
+
+namespace HE.Investment.AHP.Domain.UserContext.EventHandlers;
+
+public class InvalidateConsortiumCacheEventHandler : IEventHandler<ConsortiumMemberChangedEvent>
+{
+    private readonly ICacheService _cacheService;
+
+    public InvalidateConsortiumCacheEventHandler(ICacheService cacheService)
+    {
+        _cacheService = cacheService;
+    }
+
+    public async Task Handle(ConsortiumMemberChangedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        await _cacheService.DeleteAsync(AhpCacheKeys.OrganisationConsortium(domainEvent.OrganisationId));
+    }
+}

--- a/src/HE.Investments.AHP.Consortium.Contract/Events/ConsortiumMemberChangedEvent.cs
+++ b/src/HE.Investments.AHP.Consortium.Contract/Events/ConsortiumMemberChangedEvent.cs
@@ -1,0 +1,6 @@
+using HE.Investments.Common.Contract;
+using HE.Investments.Common.Contract.Infrastructure.Events;
+
+namespace HE.Investments.AHP.Consortium.Contract.Events;
+
+public record ConsortiumMemberChangedEvent(ConsortiumId ConsortiumId, OrganisationId OrganisationId) : IDomainEvent;

--- a/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/Entities/ConsortiumEntity.cs
@@ -2,18 +2,20 @@ extern alias Org;
 
 using HE.Investments.AHP.Consortium.Contract;
 using HE.Investments.AHP.Consortium.Contract.Enums;
+using HE.Investments.AHP.Consortium.Contract.Events;
 using HE.Investments.AHP.Consortium.Domain.Repositories;
 using HE.Investments.AHP.Consortium.Domain.ValueObjects;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Contract.Exceptions;
 using HE.Investments.Common.Contract.Validators;
+using HE.Investments.Common.Domain;
 using HE.Investments.Common.Errors;
 using HE.Investments.Common.Extensions;
 using Org::HE.Investments.Organisation.ValueObjects;
 
 namespace HE.Investments.AHP.Consortium.Domain.Entities;
 
-public class ConsortiumEntity : IConsortiumEntity
+public class ConsortiumEntity : DomainEntity, IConsortiumEntity
 {
     private readonly List<ConsortiumMember> _members;
 
@@ -67,6 +69,8 @@ public class ConsortiumEntity : IConsortiumEntity
         var member = new ConsortiumMember(organisation.Id, organisation.Name, ConsortiumMemberStatus.PendingAddition);
         _members.Add(member);
         _joinRequests.Add(member);
+
+        Publish(new ConsortiumMemberChangedEvent(Id, organisation.Id));
     }
 
     public bool AddMembersFromDraft(DraftConsortiumEntity draftConsortium, AreAllMembersAdded? requestAreAllMembersAdded)
@@ -91,6 +95,8 @@ public class ConsortiumEntity : IConsortiumEntity
             var member = new ConsortiumMember(draftMember.Id, draftMember.OrganisationName, ConsortiumMemberStatus.PendingAddition);
             _members.Add(member);
             _joinRequests.Add(member);
+
+            Publish(new ConsortiumMemberChangedEvent(Id, draftMember.Id));
         }
 
         return true;
@@ -113,6 +119,8 @@ public class ConsortiumEntity : IConsortiumEntity
         _removeRequests.Add(organisationId);
         _members.Remove(member);
         _members.Add(new ConsortiumMember(member.Id, member.OrganisationName, ConsortiumMemberStatus.PendingRemoval));
+
+        Publish(new ConsortiumMemberChangedEvent(Id, organisationId));
     }
 
     public OrganisationId? PopJoinRequest() => _joinRequests.PopItem()?.Id;

--- a/src/HE.Investments.AHP.Consortium.Domain/Repositories/ConsortiumRepository.cs
+++ b/src/HE.Investments.AHP.Consortium.Domain/Repositories/ConsortiumRepository.cs
@@ -1,12 +1,14 @@
 using HE.Investments.Account.Shared.User;
 using HE.Investments.AHP.Consortium.Contract;
 using HE.Investments.AHP.Consortium.Contract.Enums;
+using HE.Investments.AHP.Consortium.Contract.Events;
 using HE.Investments.AHP.Consortium.Domain.Crm;
 using HE.Investments.AHP.Consortium.Domain.Entities;
 using HE.Investments.AHP.Consortium.Domain.Mappers;
 using HE.Investments.AHP.Consortium.Domain.ValueObjects;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Contract.Exceptions;
+using HE.Investments.Common.Infrastructure.Events;
 
 namespace HE.Investments.AHP.Consortium.Domain.Repositories;
 
@@ -14,9 +16,12 @@ public class ConsortiumRepository : IConsortiumRepository
 {
     private readonly IConsortiumCrmContext _crmContext;
 
-    public ConsortiumRepository(IConsortiumCrmContext crmContext)
+    private readonly IEventDispatcher _eventDispatcher;
+
+    public ConsortiumRepository(IConsortiumCrmContext crmContext, IEventDispatcher eventDispatcher)
     {
         _crmContext = crmContext;
+        _eventDispatcher = eventDispatcher;
     }
 
     public async Task<ConsortiumEntity> GetConsortium(ConsortiumId consortiumId, UserAccount userAccount, CancellationToken cancellationToken)
@@ -68,9 +73,12 @@ public class ConsortiumRepository : IConsortiumRepository
                 cancellationToken);
 
             consortiumEntity.SetId(ConsortiumId.From(consortiumId));
+
+            await _eventDispatcher.Publish(new ConsortiumMemberChangedEvent(consortiumEntity.Id, consortiumEntity.LeadPartner.Id), cancellationToken);
         }
 
         await SaveConsortiumMemberRequests(consortiumEntity, userAccount, cancellationToken);
+        await _eventDispatcher.Publish(consortiumEntity, cancellationToken);
 
         return consortiumEntity;
     }


### PR DESCRIPTION
### 🛠 Changes being made

Ahp User Context uses cached consortium data, and after creating one cache was not invalidated.
Invalidating organisation consortium cache when current organisation was assigned to consortium/removed from consortium/created consortium.

Known issues:
- When other organisation was added to my consortium, cache is not invalidated, so change will be visible up to 30 minutes.
- Similar situation with changing member status on CRM.

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
