### PR TITLE
AB#99314 Add readyz and livez endpoints to all apps.

### DIFF
--- a/src/HE.Investment.AHP.WWW/Program.cs
+++ b/src/HE.Investment.AHP.WWW/Program.cs
@@ -4,6 +4,8 @@ using HE.Investments.Common.Models.App;
 using HE.Investments.Common.WWW.Infrastructure.Authorization;
 using HE.Investments.Common.WWW.Infrastructure.Cache;
 using HE.Investments.Common.WWW.Infrastructure.ErrorHandling;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 using HE.Investments.Common.WWW.Infrastructure.Middlewares;
 using HE.Investments.Common.WWW.Partials;
 using Microsoft.AspNetCore.Mvc;
@@ -20,6 +22,7 @@ builder.Services.AddCrmConnection();
 builder.Services.AddWebModule();
 builder.Services.AddFeatureManagement();
 builder.Services.AddCommonBuildingBlocks();
+builder.Services.AddHeHealthChecks(typeof(RedisHealthCheckConnector), typeof(CrmHealthCheckConnector));
 
 var mvcBuilder = builder.Services
     .AddControllersWithViews(options =>
@@ -56,6 +59,7 @@ app.UseMiddleware<HeaderSecurityMiddleware>();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapHeHealthChecks();
 
 app.Run();
 

--- a/src/HE.Investments.Account.WWW/HE.Investments.Account.WWW.csproj
+++ b/src/HE.Investments.Account.WWW/HE.Investments.Account.WWW.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MediatR" Version="12.1.1"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.24"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.13"/>
     <PackageReference Include="Microsoft.FeatureManagement" Version="3.0.0"/>
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0"/>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449"/>
-    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7" />
+    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7"/>
     <PackageReference Include="He.Identity" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Auth0" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Mvc" Version="2.1.1"/>

--- a/src/HE.Investments.Account.WWW/Program.cs
+++ b/src/HE.Investments.Account.WWW/Program.cs
@@ -4,6 +4,8 @@ using HE.Investments.Common.Models.App;
 using HE.Investments.Common.WWW.Infrastructure.Authorization;
 using HE.Investments.Common.WWW.Infrastructure.Cache;
 using HE.Investments.Common.WWW.Infrastructure.ErrorHandling;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 using HE.Investments.Common.WWW.Infrastructure.Middlewares;
 using HE.Investments.Common.WWW.Partials;
 using Microsoft.AspNetCore.Mvc;
@@ -20,6 +22,7 @@ builder.Services.AddFeatureManagement();
 builder.Services.AddCommonBuildingBlocks();
 builder.Services.AddCache(appConfig!.Cache);
 builder.Services.AddCrmConnection();
+builder.Services.AddHeHealthChecks(typeof(RedisHealthCheckConnector), typeof(CrmHealthCheckConnector));
 
 var mvcBuilder = builder.Services.AddControllersWithViews(options =>
 {
@@ -47,6 +50,7 @@ app.UseMiddleware<HeaderSecurityMiddleware>();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapHeHealthChecks();
 
 app.Run();
 

--- a/src/HE.Investments.Common.CRM/Infrastructure/CrmConnectionTester.cs
+++ b/src/HE.Investments.Common.CRM/Infrastructure/CrmConnectionTester.cs
@@ -1,0 +1,20 @@
+using HE.Investments.Common.Infrastructure.HealthChecks;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
+
+namespace HE.Investments.Common.CRM.Infrastructure;
+
+internal sealed class CrmConnectionTester : ICrmConnectionTester
+{
+    private readonly IOrganizationServiceAsync2 _serviceClient;
+
+    public CrmConnectionTester(IOrganizationServiceAsync2 serviceClient)
+    {
+        _serviceClient = serviceClient;
+    }
+
+    public async Task TestCrmConnection(CancellationToken cancellationToken)
+    {
+        await _serviceClient.ExecuteAsync(new WhoAmIRequest(), cancellationToken);
+    }
+}

--- a/src/HE.Investments.Common.CRM/Registrations.cs
+++ b/src/HE.Investments.Common.CRM/Registrations.cs
@@ -1,7 +1,9 @@
 using System.IdentityModel.Tokens.Jwt;
+using HE.Investments.Common.CRM.Infrastructure;
 using HE.Investments.Common.CRM.Services;
 using HE.Investments.Common.Extensions;
 using HE.Investments.Common.Infrastructure.Cache.Interfaces;
+using HE.Investments.Common.Infrastructure.HealthChecks;
 using HE.Investments.Common.Models.App;
 using HE.Investments.Common.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,6 +42,7 @@ public static class Registrations
         });
         services.AddScoped<ICrmService, CrmService>();
         services.Decorate<ICrmService, CrmServiceExceptionDecorator>();
+        services.AddScoped<ICrmConnectionTester, CrmConnectionTester>();
     }
 
     private static bool IsTokenExpired(JwtSecurityToken token, IDateTimeProvider dateTimeProvider)

--- a/src/HE.Investments.Common.WWW/HE.Investments.Common.WWW.csproj
+++ b/src/HE.Investments.Common.WWW/HE.Investments.Common.WWW.csproj
@@ -5,12 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1"/>
+    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7"/>
     <PackageReference Include="He.Identity.Auth0" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Mvc" Version="2.1.1"/>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.13"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.24"/>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.13"/>
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     <PackageReference Include="Stateless" Version="5.13.0"/>
   </ItemGroup>
 

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/CrmHealthCheckConnector.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/CrmHealthCheckConnector.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using HE.Investments.Common.Infrastructure.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
+
+public sealed class CrmHealthCheckConnector : IHealthCheck
+{
+    private readonly ICrmConnectionTester _crmConnectionTester;
+
+    public CrmHealthCheckConnector(ICrmConnectionTester crmConnectionTester)
+    {
+        _crmConnectionTester = crmConnectionTester;
+    }
+
+    [SuppressMessage("Design", "CA1031: Do not catch general exception types", Justification = "We need to catch all exceptions from CRM in Health Check")]
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _crmConnectionTester.TestCrmConnection(cancellationToken);
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("CRM connection not available", ex);
+        }
+    }
+}

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
@@ -1,0 +1,25 @@
+using HE.Investments.Common.Infrastructure.Cache.Config;
+using HealthChecks.Redis;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
+
+public sealed class RedisHealthCheckConnector : IHealthCheck
+{
+    private readonly ICacheConfig _cacheConfig;
+
+    public RedisHealthCheckConnector(ICacheConfig cacheConfig)
+    {
+        _cacheConfig = cacheConfig;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_cacheConfig.RedisConnectionString) || _cacheConfig.RedisConnectionString == "off")
+        {
+            return HealthCheckResult.Healthy("Redis is disabled.");
+        }
+
+        return await new RedisHealthCheck(_cacheConfig.RedisConnectionString).CheckHealthAsync(context, cancellationToken);
+    }
+}

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/EndpointRouteBuilderExtensions.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+
+public static class EndpointRouteBuilderExtensions
+{
+    public static void MapHeHealthChecks(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHealthChecks("/readyz", new HealthCheckOptions { ResponseWriter = ReadyResponseWriter });
+        endpoints.MapHealthChecks("/livez", new HealthCheckOptions { Predicate = _ => false });
+    }
+
+    private static async Task ReadyResponseWriter(HttpContext context, HealthReport report)
+    {
+        if (!context.Request.Query.ContainsKey("verbose"))
+        {
+            await HealthCheckResponseWriters.WriteMinimalPlaintextResponse(context, report);
+        }
+        else
+        {
+            await HealthCheckResponseWriters.WriteExtendedJsonResponse(context, report);
+        }
+    }
+}

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/HealthCheckResponseWriters.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/HealthCheckResponseWriters.cs
@@ -1,0 +1,49 @@
+using System.Net.Mime;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+
+namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+
+internal static class HealthCheckResponseWriters
+{
+    private static readonly byte[] DegradedBytes = Encoding.UTF8.GetBytes(HealthStatus.Degraded.ToString());
+    private static readonly byte[] HealthyBytes = Encoding.UTF8.GetBytes(HealthStatus.Healthy.ToString());
+    private static readonly byte[] UnhealthyBytes = Encoding.UTF8.GetBytes(HealthStatus.Unhealthy.ToString());
+
+    public static Task WriteMinimalPlaintextResponse(HttpContext httpContext, HealthReport result)
+    {
+        httpContext.Response.ContentType = "text/plain";
+        return result.Status switch
+        {
+            HealthStatus.Degraded => httpContext.Response.Body.WriteAsync(DegradedBytes.AsMemory()).AsTask(),
+            HealthStatus.Healthy => httpContext.Response.Body.WriteAsync(HealthyBytes.AsMemory()).AsTask(),
+            HealthStatus.Unhealthy => httpContext.Response.Body.WriteAsync(UnhealthyBytes.AsMemory()).AsTask(),
+            _ => httpContext.Response.WriteAsync(result.Status.ToString()),
+        };
+    }
+
+    public static async Task WriteExtendedJsonResponse(HttpContext httpContext, HealthReport result)
+    {
+        var response = JsonConvert.SerializeObject(
+            new { Status = result.Status.ToString(), Duration = result.TotalDuration, Info = result.Entries.Select(CreateHealthCheckDetails).ToList() },
+            Formatting.Indented,
+            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+        httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+        await httpContext.Response.WriteAsync(response);
+    }
+
+    private static object CreateHealthCheckDetails(KeyValuePair<string, HealthReportEntry> report)
+    {
+        return new
+        {
+            report.Key,
+            report.Value.Description,
+            report.Value.Duration,
+            Status = Enum.GetName(typeof(HealthStatus), report.Value.Status),
+            Error = report.Value.Exception?.Message,
+        };
+    }
+}

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/ServiceCollectionExtensions.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/ServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddHeHealthChecks(this IServiceCollection services, params Type[] healthChecks)
+    {
+        var builder = services.AddHealthChecks();
+
+        foreach (var healthCheckType in healthChecks)
+        {
+            if (!typeof(IHealthCheck).IsAssignableFrom(healthCheckType))
+            {
+                throw new ArgumentException($"{healthCheckType.Name} must implement {nameof(IHealthCheck)}");
+            }
+
+            builder.Add(new HealthCheckRegistration(
+                healthCheckType.Name,
+                x => (IHealthCheck)x.GetRequiredService(healthCheckType),
+                HealthStatus.Unhealthy,
+                null));
+        }
+
+        return services.RegisterHealthChecks(healthChecks);
+    }
+
+    private static IServiceCollection RegisterHealthChecks(this IServiceCollection services, Type[] healthChecks)
+    {
+        foreach (var healthCheckType in healthChecks)
+        {
+            services.TryAddScoped(healthCheckType);
+        }
+
+        return services;
+    }
+}

--- a/src/HE.Investments.Common/HE.Investments.Common.csproj
+++ b/src/HE.Investments.Common/HE.Investments.Common.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />

--- a/src/HE.Investments.Common/Infrastructure/HealthChecks/ICrmConnectionTester.cs
+++ b/src/HE.Investments.Common/Infrastructure/HealthChecks/ICrmConnectionTester.cs
@@ -1,0 +1,6 @@
+namespace HE.Investments.Common.Infrastructure.HealthChecks;
+
+public interface ICrmConnectionTester
+{
+    Task TestCrmConnection(CancellationToken cancellationToken);
+}

--- a/src/HE.Investments.FrontDoor.WWW/Program.cs
+++ b/src/HE.Investments.FrontDoor.WWW/Program.cs
@@ -3,6 +3,8 @@ using HE.Investments.Common.Models.App;
 using HE.Investments.Common.WWW.Infrastructure.Authorization;
 using HE.Investments.Common.WWW.Infrastructure.Cache;
 using HE.Investments.Common.WWW.Infrastructure.ErrorHandling;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 using HE.Investments.Common.WWW.Infrastructure.Middlewares;
 using HE.Investments.Common.WWW.Partials;
 using HE.Investments.FrontDoor.WWW.Config;
@@ -20,6 +22,7 @@ builder.Services.AddCrmConnection();
 builder.Services.AddWebModule();
 builder.Services.AddFeatureManagement();
 builder.Services.AddCommonBuildingBlocks();
+builder.Services.AddHeHealthChecks(typeof(RedisHealthCheckConnector), typeof(CrmHealthCheckConnector));
 
 var mvcBuilder = builder.Services
     .AddControllersWithViews(options =>
@@ -55,6 +58,7 @@ app.UseMiddleware<HeaderSecurityMiddleware>();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapHeHealthChecks();
 
 app.Run();
 

--- a/src/HE.Investments.Loans.Common/HE.Investments.Loans.Common.csproj
+++ b/src/HE.Investments.Loans.Common/HE.Investments.Loans.Common.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7" />
+    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7"/>
     <PackageReference Include="He.Identity.Auth0" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Mvc" Version="2.1.1"/>
     <PackageReference Include="MediatR" Version="12.1.1"/>
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122"/>
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     <PackageReference Include="FluentValidation" Version="11.8.0"/>
   </ItemGroup>
 

--- a/src/HE.Investments.Loans.WWW/HE.Investments.Loans.WWW.csproj
+++ b/src/HE.Investments.Loans.WWW/HE.Investments.Loans.WWW.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NuGet.Protocol" Version="6.9.1"/>
     <PackageReference Include="StackExchange.Redis.Extensions.Core" Version="9.1.0"/>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
-    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7" />
+    <PackageReference Include="He.Cookies.Mvc" Version="2.0.7"/>
     <PackageReference Include="He.Identity" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Auth0" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Mvc" Version="2.1.1"/>
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.13"/>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.13"/>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5"/>
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122"/>
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     <PackageReference Include="Stateless" Version="5.13.0"/>
     <PackageReference Include="He.AspNetCore.Mvc.Gds.Components" Version="1.0.154"/>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.15"/>

--- a/src/HE.Investments.Loans.WWW/Program.cs
+++ b/src/HE.Investments.Loans.WWW/Program.cs
@@ -2,6 +2,8 @@ using HE.Investments.Common.Models.App;
 using HE.Investments.Common.WWW.Infrastructure.Authorization;
 using HE.Investments.Common.WWW.Infrastructure.Cache;
 using HE.Investments.Common.WWW.Infrastructure.ErrorHandling;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks;
+using HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 using HE.Investments.Common.WWW.Infrastructure.Middlewares;
 using HE.Investments.Common.WWW.Partials;
 using HE.Investments.DocumentService.Extensions;
@@ -35,6 +37,7 @@ builder.Services.AddWebModule();
 builder.Services.AddFeatureManagement();
 builder.Services.AddDocumentServiceModule();
 builder.Services.AddCommonBuildingBlocks();
+builder.Services.AddHeHealthChecks(typeof(RedisHealthCheckConnector), typeof(CrmHealthCheckConnector));
 
 var mvcBuilder = builder.Services.AddControllersWithViews(x => x.Filters.Add<ExceptionFilterAttribute>());
 builder.AddIdentityProviderConfiguration(mvcBuilder);
@@ -90,6 +93,7 @@ app.UseAuthorization();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapHeHealthChecks();
 
 app.Run();
 


### PR DESCRIPTION
### 🛠 Changes being made

Added health check endpoints to Account, AHP, FrontDoor and Loans apps:
- `/livez` - checks whether app is up
- `/readyz` - check whether app is up and ready to handle requests - verifies connection with Redis and CRM which is mandatory for app to work properly
- `/readyz?verbose` - the same as above but prints details about check results

### 📸 Screenshots (optional)

<img alt="image" src="https://github.com/homesengland/he-ssp/assets/24436849/84a0e610-745c-43a3-9a87-e2dade7cdca1">


### 🏎 Quality check

- [x] Have you performed local tests?
