### PR TITLE
AB#99314 Add Document service health check endpoints + fix Redis HC.

### DIFF
--- a/src/HE.DocumentService/HE.DocumentService.Api/Program.cs
+++ b/src/HE.DocumentService/HE.DocumentService.Api/Program.cs
@@ -3,6 +3,7 @@ using HE.DocumentService.Api.Extensions;
 using HE.DocumentService.Api.Middlewares;
 using HE.DocumentService.SharePoint.Configuration;
 using HE.DocumentService.SharePoint.Extensions;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,6 +20,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddHealthChecks();
 
 var app = builder.Build();
 
@@ -37,5 +39,7 @@ app.UseAuthorization();
 app.UseMiddleware<ErrorHandlerMiddleware>();
 
 app.MapControllers();
+app.MapHealthChecks("/readyz", new HealthCheckOptions { Predicate = _ => false });
+app.MapHealthChecks("/livez", new HealthCheckOptions { Predicate = _ => false });
 
 app.Run();

--- a/src/HE.Investments.Common.WWW/HE.Investments.Common.WWW.csproj
+++ b/src/HE.Investments.Common.WWW/HE.Investments.Common.WWW.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1"/>
     <PackageReference Include="He.Cookies.Mvc" Version="2.0.7"/>
     <PackageReference Include="He.Identity.Auth0" Version="2.1.1"/>
     <PackageReference Include="He.Identity.Mvc" Version="2.1.1"/>

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/CrmHealthCheckConnector.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/CrmHealthCheckConnector.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using HE.Investments.Common.Infrastructure.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 
 namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 
@@ -8,9 +9,12 @@ public sealed class CrmHealthCheckConnector : IHealthCheck
 {
     private readonly ICrmConnectionTester _crmConnectionTester;
 
-    public CrmHealthCheckConnector(ICrmConnectionTester crmConnectionTester)
+    private readonly ILogger<CrmHealthCheckConnector> _logger;
+
+    public CrmHealthCheckConnector(ICrmConnectionTester crmConnectionTester, ILogger<CrmHealthCheckConnector> logger)
     {
         _crmConnectionTester = crmConnectionTester;
+        _logger = logger;
     }
 
     [SuppressMessage("Design", "CA1031: Do not catch general exception types", Justification = "We need to catch all exceptions from CRM in Health Check")]
@@ -23,7 +27,8 @@ public sealed class CrmHealthCheckConnector : IHealthCheck
         }
         catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy("CRM connection not available", ex);
+            _logger.LogError(ex, $"{nameof(CrmHealthCheckConnector)} failed");
+            return HealthCheckResult.Unhealthy("CRM connection not available");
         }
     }
 }

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
@@ -7,13 +7,13 @@ namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 
 public sealed class RedisHealthCheckConnector : IHealthCheck
 {
-    private readonly ICacheService _cacheConfig;
+    private readonly ICacheService _cacheService;
 
     private readonly ILogger<RedisHealthCheckConnector> _logger;
 
-    public RedisHealthCheckConnector(ICacheService cacheConfig, ILogger<RedisHealthCheckConnector> logger)
+    public RedisHealthCheckConnector(ICacheService cacheService, ILogger<RedisHealthCheckConnector> logger)
     {
-        _cacheConfig = cacheConfig;
+        _cacheService = cacheService;
         _logger = logger;
     }
 
@@ -22,7 +22,7 @@ public sealed class RedisHealthCheckConnector : IHealthCheck
     {
         try
         {
-            _cacheConfig.GetValue<string>("health-check-key");
+            _cacheService.GetValue<string>("health-check-key");
             return Task.FromResult(HealthCheckResult.Healthy());
         }
         catch (Exception ex)

--- a/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
+++ b/src/HE.Investments.Common.WWW/Infrastructure/HealthChecks/Connectors/RedisHealthCheckConnector.cs
@@ -1,25 +1,34 @@
-using HE.Investments.Common.Infrastructure.Cache.Config;
-using HealthChecks.Redis;
+using System.Diagnostics.CodeAnalysis;
+using HE.Investments.Common.Infrastructure.Cache.Interfaces;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 
 namespace HE.Investments.Common.WWW.Infrastructure.HealthChecks.Connectors;
 
 public sealed class RedisHealthCheckConnector : IHealthCheck
 {
-    private readonly ICacheConfig _cacheConfig;
+    private readonly ICacheService _cacheConfig;
 
-    public RedisHealthCheckConnector(ICacheConfig cacheConfig)
+    private readonly ILogger<RedisHealthCheckConnector> _logger;
+
+    public RedisHealthCheckConnector(ICacheService cacheConfig, ILogger<RedisHealthCheckConnector> logger)
     {
         _cacheConfig = cacheConfig;
+        _logger = logger;
     }
 
-    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    [SuppressMessage("Design", "CA1031: Do not catch general exception types", Justification = "We need to catch all exceptions from Cache service in Health Check")]
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(_cacheConfig.RedisConnectionString) || _cacheConfig.RedisConnectionString == "off")
+        try
         {
-            return HealthCheckResult.Healthy("Redis is disabled.");
+            _cacheConfig.GetValue<string>("health-check-key");
+            return Task.FromResult(HealthCheckResult.Healthy());
         }
-
-        return await new RedisHealthCheck(_cacheConfig.RedisConnectionString).CheckHealthAsync(context, cancellationToken);
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"{nameof(RedisHealthCheckConnector)} failed");
+            return Task.FromResult(HealthCheckResult.Unhealthy("Cache service connection is not available"));
+        }
     }
 }


### PR DESCRIPTION
### 🛠 Changes being made

- Added health check endpoint for Document Service.
- Reworked Redis HC to reuse the same connection as cache.
- Hide exception details when HC fails, only log exception and return status.

### 🏎 Quality check

- [x] Have you performed local tests?
