### PR TITLE
AB#99844 Fixed optionality vs validation for delivery phase milestone…

### DIFF
--- a/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/AcquisitionMilestoneDetailsTests/CreateTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/AcquisitionMilestoneDetailsTests/CreateTests.cs
@@ -6,6 +6,32 @@ namespace HE.Investment.AHP.Domain.Tests.Delivery.ValueObjects.AcquisitionMilest
 
 public class CreateTests
 {
+    [Theory]
+    [InlineData("", "1", "2024", "day")]
+    [InlineData("1", "", "2024", "month")]
+    [InlineData("1", "1", "", "year")]
+    [InlineData("1", "", "", "month and year")]
+    [InlineData("", "1", "", "day and year")]
+    [InlineData("", "", "2024", "day and month")]
+    public void ShouldThrowDomainValidationException_WhenDateIsRequiredsAndSomePartsAreAbsent(string day, string month, string year, string missingPartsText)
+    {
+        // when
+        var date = () => new AcquisitionDate(true, day, month, year);
+
+        // then
+        date.Should().Throw<DomainValidationException>().WithMessage($"The acquisition date must include a {missingPartsText}");
+    }
+
+    [Fact]
+    public void ShouldCreateEmptyDate_WhenDateIsOptional()
+    {
+        // when
+        var date = new AcquisitionDate(false, string.Empty, string.Empty, string.Empty);
+
+        date.Should().NotBeNull();
+        date.Value.Should().BeNull();
+    }
+
     [Fact]
     public void ShouldThrowDomainValidationException_WhenPaymentDateBeforeAcquisitionDate()
     {

--- a/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/CompletionMilestoneDetailsTests/CreateTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/CompletionMilestoneDetailsTests/CreateTests.cs
@@ -6,6 +6,32 @@ namespace HE.Investment.AHP.Domain.Tests.Delivery.ValueObjects.CompletionMilesto
 
 public class CreateTests
 {
+    [Theory]
+    [InlineData("", "1", "2024", "day")]
+    [InlineData("1", "", "2024", "month")]
+    [InlineData("1", "1", "", "year")]
+    [InlineData("1", "", "", "month and year")]
+    [InlineData("", "1", "", "day and year")]
+    [InlineData("", "", "2024", "day and month")]
+    public void ShouldThrowDomainValidationException_WhenDateIsRequiredsAndSomePartsAreAbsent(string day, string month, string year, string missingPartsText)
+    {
+        // when
+        var date = () => new CompletionDate(true, day, month, year);
+
+        // then
+        date.Should().Throw<DomainValidationException>().WithMessage($"The completion date must include a {missingPartsText}");
+    }
+
+    [Fact]
+    public void ShouldCreateEmptyDate_WhenDateIsOptional()
+    {
+        // when
+        var date = new CompletionDate(false, string.Empty, string.Empty, string.Empty);
+
+        date.Should().NotBeNull();
+        date.Value.Should().BeNull();
+    }
+
     [Fact]
     public void ShouldThrowDomainValidationException_WhenPaymentDateBeforeCompletionDate()
     {

--- a/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/DeliveryPhaseMilestonesTests/ValidateMilestoneDatesTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/DeliveryPhaseMilestonesTests/ValidateMilestoneDatesTests.cs
@@ -21,6 +21,32 @@ public class ValidateMilestoneDatesTests
             .Returns(Now);
     }
 
+    [Theory]
+    [InlineData("", "1", "2024", "day")]
+    [InlineData("1", "", "2024", "month")]
+    [InlineData("1", "1", "", "year")]
+    [InlineData("1", "", "", "month and year")]
+    [InlineData("", "1", "", "day and year")]
+    [InlineData("", "", "2024", "day and month")]
+    public void ShouldThrowDomainValidationException_WhenDateIsRequiredsAndSomePartsAreAbsent(string day, string month, string year, string missingPartsText)
+    {
+        // when
+        var date = () => new MilestonePaymentDate(true, day, month, year);
+
+        // then
+        date.Should().Throw<DomainValidationException>().WithMessage($"The milestone payment date must include a {missingPartsText}");
+    }
+
+    [Fact]
+    public void ShouldCreateEmptyDate_WhenDateIsOptional()
+    {
+        // when
+        var date = new MilestonePaymentDate(false, string.Empty, string.Empty, string.Empty);
+
+        date.Should().NotBeNull();
+        date.Value.Should().BeNull();
+    }
+
     [Fact]
     public void ShouldThrowException_WhenStartOnSiteMilestoneIsBeforeAcquisitionMilestone()
     {

--- a/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/StartOnSiteMilestoneDetailsTests/CreateTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Delivery/ValueObjects/StartOnSiteMilestoneDetailsTests/CreateTests.cs
@@ -6,6 +6,32 @@ namespace HE.Investment.AHP.Domain.Tests.Delivery.ValueObjects.StartOnSiteMilest
 
 public class CreateTests
 {
+    [Theory]
+    [InlineData("", "1", "2024", "day")]
+    [InlineData("1", "", "2024", "month")]
+    [InlineData("1", "1", "", "year")]
+    [InlineData("1", "", "", "month and year")]
+    [InlineData("", "1", "", "day and year")]
+    [InlineData("", "", "2024", "day and month")]
+    public void ShouldThrowDomainValidationException_WhenDateIsRequiredsAndSomePartsAreAbsent(string day, string month, string year, string missingPartsText)
+    {
+        // when
+        var date = () => new StartOnSiteDate(true, day, month, year);
+
+        // then
+        date.Should().Throw<DomainValidationException>().WithMessage($"The start on site date must include a {missingPartsText}");
+    }
+
+    [Fact]
+    public void ShouldCreateEmptyDate_WhenDateIsOptional()
+    {
+        // when
+        var date = new StartOnSiteDate(false, string.Empty, string.Empty, string.Empty);
+
+        date.Should().NotBeNull();
+        date.Value.Should().BeNull();
+    }
+
     [Fact]
     public void ShouldThrowDomainValidationException_WhenPaymentDateBeforeStartOnSiteDate()
     {

--- a/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/AcquisitionDate.cs
+++ b/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/AcquisitionDate.cs
@@ -18,5 +18,5 @@ public class AcquisitionDate : DateValueObject
     }
 
     public static AcquisitionDate FromDateDetails(DateDetails? date) =>
-        new(date is { IsNotEmpty: true }, date?.Day, date?.Month, date?.Year);
+        new(date is { IsEmpty: false }, date?.Day, date?.Month, date?.Year);
 }

--- a/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/CompletionDate.cs
+++ b/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/CompletionDate.cs
@@ -18,5 +18,5 @@ public class CompletionDate : DateValueObject
     }
 
     public static CompletionDate FromDateDetails(DateDetails? date) =>
-        new(date is { IsNotEmpty: true }, date?.Day, date?.Month, date?.Year);
+        new(date is { IsEmpty: false }, date?.Day, date?.Month, date?.Year);
 }

--- a/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/MilestonePaymentDate.cs
+++ b/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/MilestonePaymentDate.cs
@@ -18,5 +18,5 @@ public class MilestonePaymentDate : DateValueObject
     }
 
     public static MilestonePaymentDate FromDateDetails(DateDetails? date) =>
-        new(date is { IsNotEmpty: true }, date?.Day, date?.Month, date?.Year);
+        new(date is { IsEmpty: false }, date?.Day, date?.Month, date?.Year);
 }

--- a/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/StartOnSiteDate.cs
+++ b/src/HE.Investment.AHP.Domain/Delivery/ValueObjects/StartOnSiteDate.cs
@@ -18,5 +18,5 @@ public class StartOnSiteDate : DateValueObject
     }
 
     public static StartOnSiteDate FromDateDetails(DateDetails? date) =>
-        new(date is { IsNotEmpty: true }, date?.Day, date?.Month, date?.Year);
+        new(date is { IsEmpty: false }, date?.Day, date?.Month, date?.Year);
 }

--- a/src/HE.Investments.Common.Contract/DateDetails.cs
+++ b/src/HE.Investments.Common.Contract/DateDetails.cs
@@ -4,7 +4,7 @@ namespace HE.Investments.Common.Contract;
 
 public record DateDetails(string? Day, string? Month, string? Year)
 {
-    public bool IsNotEmpty => !string.IsNullOrEmpty(Day) && !string.IsNullOrEmpty(Month) && !string.IsNullOrEmpty(Year);
+    public bool IsEmpty => string.IsNullOrEmpty(Day) && string.IsNullOrEmpty(Month) && string.IsNullOrEmpty(Year);
 
     public static DateDetails Empty() => new(string.Empty, string.Empty, string.Empty);
 


### PR DESCRIPTION
… dates

### 🛠 Changes being made

Made milestone date pages allow skipping only when input boxes are empty. When any part of date was filled the validation fires and doesn't allow saving until date is fixed or all parts removed.

### 📸 Screenshots (optional)

Insert some screenshots if you made UI changes.

### 🏎 Quality check

- [x] Have you performed local tests?
- [ ] Are integration tests passing locally? - I don't know because project list request throws exception for admin account and I need admin to create consortium for integration tests
- [x] Have you added some unit tests?
- [ ] Have you added some integration tests?
- [ ] Have you checked WCAG (included screenshot)
