### PR TITLE
AB#99638 AB#99735 AB#99159 Fix some UI texts.

### DIFF
--- a/src/HE.Investment.AHP.Contract/HomeTypes/Enums/ModernMethodsConstruction2DSubcategoriesType.cs
+++ b/src/HE.Investment.AHP.Contract/HomeTypes/Enums/ModernMethodsConstruction2DSubcategoriesType.cs
@@ -12,6 +12,6 @@ public enum ModernMethodsConstruction2DSubcategoriesType
     [Description("Enhanced consolidation, for example insulation or internal linings ")]
     EnhancedConsolidation,
 
-    [Description("Further enhanced consolidation, including: insulation, linings, external, cladding, roofing, doors, windows")]
+    [Description("Further enhanced consolidation, including: insulation, linings, external cladding, roofing, doors, windows")]
     FurtherEnhancedConsolidation,
 }

--- a/src/HE.Investment.AHP.Domain/HomeTypes/ValueObjects/FloorArea.cs
+++ b/src/HE.Investment.AHP.Domain/HomeTypes/ValueObjects/FloorArea.cs
@@ -5,7 +5,7 @@ namespace HE.Investment.AHP.Domain.HomeTypes.ValueObjects;
 
 public class FloorArea : TheRequiredDecimalValueObject
 {
-    private const string DisplayName = "square meterage in the internal floor each of each home";
+    private const string DisplayName = "square meterage in the internal floor area of each home";
 
     private const decimal MinValue = 0;
 

--- a/src/HE.Investment.AHP.WWW/Views/Site/BuildingForHealthyLife.cshtml
+++ b/src/HE.Investment.AHP.WWW/Views/Site/BuildingForHealthyLife.cshtml
@@ -19,7 +19,7 @@
             title = "What are the Building for a Healthy Life criteria?",
             contentText = "Building for a Healthy Life is a design code to help people improve the design of new and growing neighbourhoods. You can read more in the",
             linkUrl = ExternalLinks.BuildingForHealthyLife,
-            linkText = "Building for a Healthy life toolkit (opens in a new tab).",
+            linkText = "Building for a Healthy Life toolkit (opens in a new tab).",
             header = SitePageTitles.BuildingForHealthyLife
         });
 }

--- a/src/HE.Investments.Common/Messages/ValidationErrorMessage.cs
+++ b/src/HE.Investments.Common/Messages/ValidationErrorMessage.cs
@@ -119,7 +119,7 @@ public static class ValidationErrorMessage
 
     public static string MustIncludeThePence(string displayName, string? example) => $"The {displayName} must include pence{Example(example)}";
 
-    public static string MustIncludeThePrecision(string displayName, int precision, string? example) => $"The {displayName} must include {precision} decimal places{Example(example)}";
+    public static string MustIncludeThePrecision(string displayName, int precision, string? example) => $"Enter the {displayName} up to {precision} decimal places{Example(example)}";
 
     public static string MustBeTheNumber(string displayName, string? example) => $"The {displayName} must be a number{Example(example)}";
 


### PR DESCRIPTION
### 🛠 Changes being made

Changed:
- MMC Category 2D text.
- Healthy Life link text.
- Decimal invalid precision error message.

### 📸 Screenshots (optional)

![Zrzut ekranu 2024-06-14 133625](https://github.com/homesengland/he-ssp/assets/24436849/648e9a7c-46f0-4550-b33d-1fcdd9375d2d)

<img alt="image" src="https://github.com/homesengland/he-ssp/assets/24436849/2b4adea8-bc2b-4f98-b928-70f9e2f90046">

<img alt="image" src="https://github.com/homesengland/he-ssp/assets/24436849/a2a91efb-0ed1-4257-be2a-c4d67e884ee5">


### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you checked WCAG (included screenshot)