### PR TITLE
AB#100138 Update error messages for site and application partners

### DIFF
--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithDevelopingPartnerTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithDevelopingPartnerTests.cs
@@ -61,7 +61,7 @@ public class WithDevelopingPartnerTests
         var provide = () => testCandidate.WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the developing partner");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the developing partner");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheHomesTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheHomesTests.cs
@@ -61,7 +61,7 @@ public class WithOwnerOfTheHomesTests
         var provide = () => testCandidate.WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the owner of the homes after completion");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the owner of the homes after completion");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheLandTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Scheme/ValueObjects/ApplicationPartnersTests/WithOwnerOfTheLandTests.cs
@@ -61,7 +61,7 @@ public class WithOwnerOfTheLandTests
         var provide = () => testCandidate.WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the owner of the land during development");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the owner of the land during development");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithDevelopingPartnerTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithDevelopingPartnerTests.cs
@@ -17,7 +17,7 @@ public class WithDevelopingPartnerTests
         var provide = () => testCandidate.WithDevelopingPartner(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the developing partner");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the developing partner");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithOwnerOfTheHomesTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithOwnerOfTheHomesTests.cs
@@ -17,7 +17,7 @@ public class WithOwnerOfTheHomesTests
         var provide = () => testCandidate.WithOwnerOfTheHomes(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the owner of the homes after completion");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the owner of the homes after completion");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithOwnerOfTheLandTests.cs
+++ b/src/HE.Investment.AHP.Domain.Tests/Site/ValueObjects/SitePartnersTests/WithOwnerOfTheLandTests.cs
@@ -17,7 +17,7 @@ public class WithOwnerOfTheLandTests
         var provide = () => testCandidate.WithOwnerOfTheLand(InvestmentsOrganisationTestData.JjCompany, null);
 
         // then
-        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes if you want to confirm the owner of the land during development");
+        provide.Should().Throw<DomainValidationException>().WithMessage("Select yes to confirm the owner of the land during development");
     }
 
     [Fact]

--- a/src/HE.Investment.AHP.Domain/Scheme/ValueObjects/ApplicationPartners.cs
+++ b/src/HE.Investment.AHP.Domain/Scheme/ValueObjects/ApplicationPartners.cs
@@ -106,7 +106,7 @@ public class ApplicationPartners : ValueObject
     {
         if (isPartnerConfirmed == null)
         {
-            OperationResult.ThrowValidationError(nameof(isPartnerConfirmed), $"Select yes if you want to confirm the {partnerType}");
+            OperationResult.ThrowValidationError(nameof(isPartnerConfirmed), $"Select yes to confirm the {partnerType}");
         }
 
         if (isPartnerConfirmed!.Value)

--- a/src/HE.Investment.AHP.Domain/Site/ValueObjects/SitePartners.cs
+++ b/src/HE.Investment.AHP.Domain/Site/ValueObjects/SitePartners.cs
@@ -67,7 +67,7 @@ public class SitePartners : ValueObject, IQuestion
     {
         if (isConfirmed == null)
         {
-            OperationResult.ThrowValidationError(nameof(isConfirmed), $"Select yes if you want to confirm the {partnerType}");
+            OperationResult.ThrowValidationError(nameof(isConfirmed), $"Select yes to confirm the {partnerType}");
         }
 
         return isConfirmed!.Value


### PR DESCRIPTION
### 🛠 Changes being made

New error messages for site and application partners:
Select yes to confirm the developing partner
Select yes to confirm the owner of the land during development
Select yes to confirm the owner of the homes after completion

### 📸 Screenshots (optional)

![image](https://github.com/homesengland/he-ssp/assets/130044868/2e4b4a77-dbd8-4e28-b0eb-fb1c6485ad11)

### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
