### PR TITLE
AB#102109 Calculate Due Claim status based on forecast claim date.

### DIFF
--- a/src/HE.Investment.AHP.WWW/Views/Shared/Components/ClaimStatusTag/ClaimStatusTag.cshtml
+++ b/src/HE.Investment.AHP.WWW/Views/Shared/Components/ClaimStatusTag/ClaimStatusTag.cshtml
@@ -1,6 +1,10 @@
+@using HE.Investments.AHP.Allocation.Contract.Claims.Enum
 @using HE.Investments.Common.Extensions
 @model (HE.Investments.AHP.Allocation.Contract.Claims.Enum.MilestoneStatus Status, HE.Investments.Common.Gds.TagColour TagColour)
 
-<strong class="govuk-tag govuk-tag--@Model.TagColour.GetDescription().ToLowerInvariant()">
-    @Model.Status.GetDescription()
-</strong>
+@if (Model.Status != MilestoneStatus.Undefined)
+{
+    <strong class="govuk-tag govuk-tag--@Model.TagColour.GetDescription().ToLowerInvariant()">
+        @Model.Status.GetDescription()
+    </strong>
+}

--- a/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/ClaimsContractMapperTests.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/ClaimsContractMapperTests.cs
@@ -4,19 +4,13 @@ using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
 using HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
 using HE.Investments.AHP.Allocation.Domain.Tests.TestObjectBuilders;
 using HE.Investments.Common.Contract.Pagination;
+using HE.Investments.TestsUtils.TestFramework;
 using Xunit;
 
 namespace HE.Investments.AHP.Allocation.Domain.Tests.Claims.Mappers;
 
-public class ClaimsContractMapperTests
+public class ClaimsContractMapperTests : TestBase<ClaimsContractMapper>
 {
-    private readonly ClaimsContractMapper _mapper;
-
-    public ClaimsContractMapperTests()
-    {
-        _mapper = new ClaimsContractMapper();
-    }
-
     [Fact]
     public void ShouldReturnCorrectAllocationDetails_WhenDataIsValid()
     {
@@ -26,7 +20,7 @@ public class ClaimsContractMapperTests
             .Build();
 
         // when
-        var result = _mapper.Map(allocation, new PaginationRequest(1));
+        var result = TestCandidate.Map(allocation, new PaginationRequest(1));
 
         // then
         result.AllocationBasicInfo.Id.Should().Be(allocation.Id);
@@ -45,7 +39,7 @@ public class ClaimsContractMapperTests
         var phase = PhaseEntityTestBuilder.New().Build();
 
         // when
-        var result = _mapper.Map(phase);
+        var result = TestCandidate.Map(phase);
 
         // then
         result.MilestoneClaims.Count.Should().Be(1);
@@ -63,7 +57,7 @@ public class ClaimsContractMapperTests
             .Build();
 
         // when
-        var result = _mapper.Map(MilestoneType.Completion, milestoneClaim);
+        var result = TestCandidate.Map(MilestoneType.Completion, milestoneClaim);
 
         // then
         result!.ForecastClaimDate.Should().NotBeNull();
@@ -80,7 +74,7 @@ public class ClaimsContractMapperTests
     public void ShouldReturnNull_WhenMilestoneClaimIsNull()
     {
         // given && when
-        var result = _mapper.Map(MilestoneType.Completion, null);
+        var result = TestCandidate.Map(MilestoneType.Completion, null);
 
         // then
         result.Should().BeNull();

--- a/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/MilestoneClaimStatusMapperTests.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/MilestoneClaimStatusMapperTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
+using HE.Investments.AHP.Allocation.Domain.Claims.Enums;
 using HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
-using HE.Investments.Common.Utils;
 using HE.Investments.TestsUtils.TestFramework;
 using Xunit;
 using ContractMilestoneStatus = HE.Investments.AHP.Allocation.Contract.Claims.Enum.MilestoneStatus;
@@ -10,83 +10,36 @@ namespace HE.Investments.AHP.Allocation.Domain.Tests.Claims.Mappers;
 
 public class MilestoneClaimStatusMapperTests : TestBase<MilestoneClaimStatusMapper>
 {
-    private readonly DateTime _today = new(2024, 07, 20, 0, 0, 0, DateTimeKind.Local);
-
-    public MilestoneClaimStatusMapperTests()
-    {
-        var dateTimeProvider = CreateAndRegisterDependencyMock<IDateTimeProvider>();
-
-        dateTimeProvider.Setup(x => x.Now).Returns(_today);
-    }
-
     [Theory]
     [InlineData(DomainMilestoneStatus.Submitted, ContractMilestoneStatus.Submitted)]
     [InlineData(DomainMilestoneStatus.UnderReview, ContractMilestoneStatus.UnderReview)]
     [InlineData(DomainMilestoneStatus.Approved, ContractMilestoneStatus.Approved)]
     [InlineData(DomainMilestoneStatus.Rejected, ContractMilestoneStatus.Rejected)]
     [InlineData(DomainMilestoneStatus.Reclaimed, ContractMilestoneStatus.Reclaimed)]
-    public void ShouldReturnTheSameStatus_WhenStatusCanBeMappedDirectly(DomainMilestoneStatus domainStatus, ContractMilestoneStatus contractStatus)
+    public void ShouldReturnTheSameStatus_WhenStatusCanBeMappedDirectly(DomainMilestoneStatus domainStatus, ContractMilestoneStatus expectedStatus)
     {
         // given & when
-        var result = TestCandidate.MapStatus(domainStatus, _today);
+        var result = TestCandidate.MapStatus(domainStatus, MilestoneDueStatus.Due);
 
         // then
-        result.Should().Be(contractStatus);
+        result.Should().Be(expectedStatus);
     }
 
     [Theory]
-    [InlineData(DomainMilestoneStatus.Undefined, 15)]
-    [InlineData(DomainMilestoneStatus.Draft, 15)]
-    [InlineData(DomainMilestoneStatus.Undefined, 150)]
-    [InlineData(DomainMilestoneStatus.Draft, 150)]
-    public void ShouldReturnUndefinedStatus_WhenItIsMoreThan14DaysBeforeForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
+    [InlineData(DomainMilestoneStatus.Undefined, MilestoneDueStatus.Undefined, ContractMilestoneStatus.Undefined)]
+    [InlineData(DomainMilestoneStatus.Undefined, MilestoneDueStatus.Due, ContractMilestoneStatus.Due)]
+    [InlineData(DomainMilestoneStatus.Undefined, MilestoneDueStatus.DueSoon, ContractMilestoneStatus.DueSoon)]
+    [InlineData(DomainMilestoneStatus.Undefined, MilestoneDueStatus.Overdue, ContractMilestoneStatus.Overdue)]
+    [InlineData(DomainMilestoneStatus.Draft, MilestoneDueStatus.Undefined, ContractMilestoneStatus.Undefined)]
+    [InlineData(DomainMilestoneStatus.Draft, MilestoneDueStatus.Due, ContractMilestoneStatus.Due)]
+    [InlineData(DomainMilestoneStatus.Draft, MilestoneDueStatus.DueSoon, ContractMilestoneStatus.DueSoon)]
+    [InlineData(DomainMilestoneStatus.Draft, MilestoneDueStatus.Overdue, ContractMilestoneStatus.Overdue)]
+    public void ShouldReturnDueStatus_WhenStatusIs(DomainMilestoneStatus domainStatus, MilestoneDueStatus dueStatus, ContractMilestoneStatus expectedStatus)
     {
         // given & when
-        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
+        var result = TestCandidate.MapStatus(domainStatus, dueStatus);
 
         // then
-        result.Should().Be(ContractMilestoneStatus.Undefined);
-    }
-
-    [Theory]
-    [InlineData(DomainMilestoneStatus.Undefined, 14)]
-    [InlineData(DomainMilestoneStatus.Draft, 14)]
-    [InlineData(DomainMilestoneStatus.Undefined, 7)]
-    [InlineData(DomainMilestoneStatus.Draft, 7)]
-    public void ShouldReturnDueSoonStatus_WhenItIsBetween14And7DaysBeforeForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
-    {
-        // given & when
-        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
-
-        // then
-        result.Should().Be(ContractMilestoneStatus.DueSoon);
-    }
-
-    [Theory]
-    [InlineData(DomainMilestoneStatus.Undefined, 6)]
-    [InlineData(DomainMilestoneStatus.Draft, 6)]
-    [InlineData(DomainMilestoneStatus.Undefined, -6)]
-    [InlineData(DomainMilestoneStatus.Draft, -6)]
-    public void ShouldReturnDueStatus_WhenItIsBetween6DaysBeforeAnd6DaysAfterForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
-    {
-        // given & when
-        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
-
-        // then
-        result.Should().Be(ContractMilestoneStatus.Due);
-    }
-
-    [Theory]
-    [InlineData(DomainMilestoneStatus.Undefined, 7)]
-    [InlineData(DomainMilestoneStatus.Draft, 7)]
-    [InlineData(DomainMilestoneStatus.Undefined, 150)]
-    [InlineData(DomainMilestoneStatus.Draft, 150)]
-    public void ShouldReturnOverdueStatus_WhenItIsMoreThan6DaysAfterForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
-    {
-        // given & when
-        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(-days));
-
-        // then
-        result.Should().Be(ContractMilestoneStatus.Overdue);
+        result.Should().Be(expectedStatus);
     }
 }

--- a/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/MilestoneClaimStatusMapperTests.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain.Tests/Claims/Mappers/MilestoneClaimStatusMapperTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
+using HE.Investments.Common.Utils;
+using HE.Investments.TestsUtils.TestFramework;
+using Xunit;
+using ContractMilestoneStatus = HE.Investments.AHP.Allocation.Contract.Claims.Enum.MilestoneStatus;
+using DomainMilestoneStatus = HE.Investments.AHP.Allocation.Domain.Claims.Enums.MilestoneStatus;
+
+namespace HE.Investments.AHP.Allocation.Domain.Tests.Claims.Mappers;
+
+public class MilestoneClaimStatusMapperTests : TestBase<MilestoneClaimStatusMapper>
+{
+    private readonly DateTime _today = new(2024, 07, 20, 0, 0, 0, DateTimeKind.Local);
+
+    public MilestoneClaimStatusMapperTests()
+    {
+        var dateTimeProvider = CreateAndRegisterDependencyMock<IDateTimeProvider>();
+
+        dateTimeProvider.Setup(x => x.Now).Returns(_today);
+    }
+
+    [Theory]
+    [InlineData(DomainMilestoneStatus.Submitted, ContractMilestoneStatus.Submitted)]
+    [InlineData(DomainMilestoneStatus.UnderReview, ContractMilestoneStatus.UnderReview)]
+    [InlineData(DomainMilestoneStatus.Approved, ContractMilestoneStatus.Approved)]
+    [InlineData(DomainMilestoneStatus.Rejected, ContractMilestoneStatus.Rejected)]
+    [InlineData(DomainMilestoneStatus.Reclaimed, ContractMilestoneStatus.Reclaimed)]
+    public void ShouldReturnTheSameStatus_WhenStatusCanBeMappedDirectly(DomainMilestoneStatus domainStatus, ContractMilestoneStatus contractStatus)
+    {
+        // given & when
+        var result = TestCandidate.MapStatus(domainStatus, _today);
+
+        // then
+        result.Should().Be(contractStatus);
+    }
+
+    [Theory]
+    [InlineData(DomainMilestoneStatus.Undefined, 15)]
+    [InlineData(DomainMilestoneStatus.Draft, 15)]
+    [InlineData(DomainMilestoneStatus.Undefined, 150)]
+    [InlineData(DomainMilestoneStatus.Draft, 150)]
+    public void ShouldReturnUndefinedStatus_WhenItIsMoreThan14DaysBeforeForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
+    {
+        // given & when
+        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
+
+        // then
+        result.Should().Be(ContractMilestoneStatus.Undefined);
+    }
+
+    [Theory]
+    [InlineData(DomainMilestoneStatus.Undefined, 14)]
+    [InlineData(DomainMilestoneStatus.Draft, 14)]
+    [InlineData(DomainMilestoneStatus.Undefined, 7)]
+    [InlineData(DomainMilestoneStatus.Draft, 7)]
+    public void ShouldReturnDueSoonStatus_WhenItIsBetween14And7DaysBeforeForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
+    {
+        // given & when
+        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
+
+        // then
+        result.Should().Be(ContractMilestoneStatus.DueSoon);
+    }
+
+    [Theory]
+    [InlineData(DomainMilestoneStatus.Undefined, 6)]
+    [InlineData(DomainMilestoneStatus.Draft, 6)]
+    [InlineData(DomainMilestoneStatus.Undefined, -6)]
+    [InlineData(DomainMilestoneStatus.Draft, -6)]
+    public void ShouldReturnDueStatus_WhenItIsBetween6DaysBeforeAnd6DaysAfterForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
+    {
+        // given & when
+        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(days));
+
+        // then
+        result.Should().Be(ContractMilestoneStatus.Due);
+    }
+
+    [Theory]
+    [InlineData(DomainMilestoneStatus.Undefined, 7)]
+    [InlineData(DomainMilestoneStatus.Draft, 7)]
+    [InlineData(DomainMilestoneStatus.Undefined, 150)]
+    [InlineData(DomainMilestoneStatus.Draft, 150)]
+    public void ShouldReturnOverdueStatus_WhenItIsMoreThan6DaysAfterForecastClaimDateAndStatusIs(DomainMilestoneStatus domainStatus, int days)
+    {
+        // given & when
+        var result = TestCandidate.MapStatus(domainStatus, _today.AddDays(-days));
+
+        // then
+        result.Should().Be(ContractMilestoneStatus.Overdue);
+    }
+}

--- a/src/HE.Investments.AHP.Allocation.Domain/Allocation/Crm/AllocationCrmContext.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Allocation/Crm/AllocationCrmContext.cs
@@ -87,7 +87,7 @@ public class AllocationCrmContext : IAllocationCrmContext
                         Status = 1,
                         AmountOfGrantApportioned = 10000m,
                         PercentageOfGrantApportioned = 40,
-                        ForecastClaimDate = DateTime.Today,
+                        ForecastClaimDate = DateTime.Today.AddDays(-7),
                     },
                     StartOnSiteMilestone = new MilestoneClaimDto()
                     {
@@ -95,7 +95,7 @@ public class AllocationCrmContext : IAllocationCrmContext
                         Status = 1,
                         AmountOfGrantApportioned = 20000m,
                         PercentageOfGrantApportioned = 40,
-                        ForecastClaimDate = DateTime.Today.AddDays(10),
+                        ForecastClaimDate = DateTime.Today.AddDays(-6),
                     },
                     CompletionMilestone = new MilestoneClaimDto()
                     {
@@ -103,7 +103,7 @@ public class AllocationCrmContext : IAllocationCrmContext
                         Status = 1,
                         AmountOfGrantApportioned = 30000m,
                         PercentageOfGrantApportioned = 20,
-                        ForecastClaimDate = DateTime.Today.AddDays(40),
+                        ForecastClaimDate = DateTime.Today.AddDays(7),
                     },
                 },
                 new()

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Enums/MilestoneDueStatus.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Enums/MilestoneDueStatus.cs
@@ -1,0 +1,9 @@
+namespace HE.Investments.AHP.Allocation.Domain.Claims.Enums;
+
+public enum MilestoneDueStatus
+{
+    Undefined,
+    DueSoon,
+    Due,
+    Overdue,
+}

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/ClaimsContractMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/ClaimsContractMapper.cs
@@ -10,8 +10,15 @@ using HE.Investments.Common.Extensions;
 
 namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
 
-public class ClaimsContractMapper : IClaimsContractMapper
+public sealed class ClaimsContractMapper : IClaimsContractMapper
 {
+    private readonly IMilestoneClaimStatusMapper _milestoneClaimStatusMapper;
+
+    public ClaimsContractMapper(IMilestoneClaimStatusMapper milestoneClaimStatusMapper)
+    {
+        _milestoneClaimStatusMapper = milestoneClaimStatusMapper;
+    }
+
     public AllocationDetails Map(AllocationEntity allocation, PaginationRequest paginationRequest)
     {
         var allocationBasicInfo = new AllocationBasicInfo(
@@ -65,8 +72,8 @@ public class ClaimsContractMapper : IClaimsContractMapper
 
         return new MilestoneClaim(
             milestoneType,
-            MilestoneStatus.Due, // TODO: AB#102109 Calculate display status
-            milestoneClaim!.GrantApportioned.Amount,
+            _milestoneClaimStatusMapper.MapStatus(milestoneClaim!.Status, milestoneClaim.ClaimDate.ForecastClaimDate),
+            milestoneClaim.GrantApportioned.Amount,
             milestoneClaim.GrantApportioned.Percentage,
             DateDetails.FromDateTime(milestoneClaim.ClaimDate.ForecastClaimDate)!,
             DateDetails.FromDateTime(milestoneClaim.ClaimDate.ActualClaimDate),
@@ -74,7 +81,7 @@ public class ClaimsContractMapper : IClaimsContractMapper
             false); // TODO: AB#102144 Calculate whether can be claimed
     }
 
-    private AllocationBasicInfo Map(Allocation.ValueObjects.AllocationBasicInfo allocationBasicInfo)
+    private static AllocationBasicInfo Map(Allocation.ValueObjects.AllocationBasicInfo allocationBasicInfo)
     {
         return new(
             allocationBasicInfo.Id,
@@ -85,7 +92,7 @@ public class ClaimsContractMapper : IClaimsContractMapper
             allocationBasicInfo.Tenure);
     }
 
-    private GrantDetails Map(Allocation.ValueObjects.GrantDetails grantDetails)
+    private static GrantDetails Map(Allocation.ValueObjects.GrantDetails grantDetails)
     {
         return new GrantDetails(
             grantDetails.TotalGrantAllocated,

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/ClaimsContractMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/ClaimsContractMapper.cs
@@ -7,6 +7,7 @@ using HE.Investments.AHP.Allocation.Domain.Claims.Entities;
 using HE.Investments.Common.Contract;
 using HE.Investments.Common.Contract.Pagination;
 using HE.Investments.Common.Extensions;
+using HE.Investments.Common.Utils;
 
 namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
 
@@ -14,9 +15,12 @@ public sealed class ClaimsContractMapper : IClaimsContractMapper
 {
     private readonly IMilestoneClaimStatusMapper _milestoneClaimStatusMapper;
 
-    public ClaimsContractMapper(IMilestoneClaimStatusMapper milestoneClaimStatusMapper)
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public ClaimsContractMapper(IMilestoneClaimStatusMapper milestoneClaimStatusMapper, IDateTimeProvider dateTimeProvider)
     {
         _milestoneClaimStatusMapper = milestoneClaimStatusMapper;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public AllocationDetails Map(AllocationEntity allocation, PaginationRequest paginationRequest)
@@ -72,7 +76,7 @@ public sealed class ClaimsContractMapper : IClaimsContractMapper
 
         return new MilestoneClaim(
             milestoneType,
-            _milestoneClaimStatusMapper.MapStatus(milestoneClaim!.Status, milestoneClaim.ClaimDate.ForecastClaimDate),
+            _milestoneClaimStatusMapper.MapStatus(milestoneClaim!.Status, milestoneClaim.CalculateDueStatus(_dateTimeProvider)),
             milestoneClaim.GrantApportioned.Amount,
             milestoneClaim.GrantApportioned.Percentage,
             DateDetails.FromDateTime(milestoneClaim.ClaimDate.ForecastClaimDate)!,

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/IMilestoneClaimStatusMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/IMilestoneClaimStatusMapper.cs
@@ -1,0 +1,8 @@
+using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
+
+namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
+
+public interface IMilestoneClaimStatusMapper
+{
+    MilestoneStatus MapStatus(Enums.MilestoneStatus status, DateTime forecastClaimDate);
+}

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/IMilestoneClaimStatusMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/IMilestoneClaimStatusMapper.cs
@@ -1,8 +1,9 @@
-using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
+using HE.Investments.AHP.Allocation.Domain.Claims.Enums;
+using MilestoneStatus = HE.Investments.AHP.Allocation.Contract.Claims.Enum.MilestoneStatus;
 
 namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
 
 public interface IMilestoneClaimStatusMapper
 {
-    MilestoneStatus MapStatus(Enums.MilestoneStatus status, DateTime forecastClaimDate);
+    MilestoneStatus MapStatus(Enums.MilestoneStatus status, MilestoneDueStatus dueStatus);
 }

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/MilestoneClaimStatusMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/MilestoneClaimStatusMapper.cs
@@ -1,0 +1,51 @@
+using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
+using HE.Investments.Common.Extensions;
+using HE.Investments.Common.Utils;
+
+namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
+
+public sealed class MilestoneClaimStatusMapper : IMilestoneClaimStatusMapper
+{
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public MilestoneClaimStatusMapper(IDateTimeProvider dateTimeProvider)
+    {
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public MilestoneStatus MapStatus(Enums.MilestoneStatus status, DateTime forecastClaimDate)
+    {
+        return status switch
+        {
+            Enums.MilestoneStatus.Undefined => CalculateDueStatus(forecastClaimDate),
+            Enums.MilestoneStatus.Draft => CalculateDueStatus(forecastClaimDate),
+            Enums.MilestoneStatus.Submitted => MilestoneStatus.Submitted,
+            Enums.MilestoneStatus.UnderReview => MilestoneStatus.UnderReview,
+            Enums.MilestoneStatus.Approved => MilestoneStatus.Approved,
+            Enums.MilestoneStatus.Rejected => MilestoneStatus.Rejected,
+            Enums.MilestoneStatus.Reclaimed => MilestoneStatus.Reclaimed,
+            _ => MilestoneStatus.Undefined,
+        };
+    }
+
+    private MilestoneStatus CalculateDueStatus(DateTime forecastClaimDate)
+    {
+        var today = _dateTimeProvider.Now.Date;
+        if (forecastClaimDate.Date.IsAfter(today.AddDays(14)))
+        {
+            return MilestoneStatus.Undefined;
+        }
+
+        if (forecastClaimDate.Date.IsAfter(today.AddDays(6)))
+        {
+            return MilestoneStatus.DueSoon;
+        }
+
+        if (forecastClaimDate.Date.IsAfter(today.AddDays(-7)))
+        {
+            return MilestoneStatus.Due;
+        }
+
+        return MilestoneStatus.Overdue;
+    }
+}

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/MilestoneClaimStatusMapper.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/Mappers/MilestoneClaimStatusMapper.cs
@@ -1,24 +1,18 @@
-using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
+using HE.Investments.AHP.Allocation.Domain.Claims.Enums;
 using HE.Investments.Common.Extensions;
 using HE.Investments.Common.Utils;
+using MilestoneStatus = HE.Investments.AHP.Allocation.Contract.Claims.Enum.MilestoneStatus;
 
 namespace HE.Investments.AHP.Allocation.Domain.Claims.Mappers;
 
 public sealed class MilestoneClaimStatusMapper : IMilestoneClaimStatusMapper
 {
-    private readonly IDateTimeProvider _dateTimeProvider;
-
-    public MilestoneClaimStatusMapper(IDateTimeProvider dateTimeProvider)
-    {
-        _dateTimeProvider = dateTimeProvider;
-    }
-
-    public MilestoneStatus MapStatus(Enums.MilestoneStatus status, DateTime forecastClaimDate)
+    public MilestoneStatus MapStatus(Enums.MilestoneStatus status, MilestoneDueStatus dueStatus)
     {
         return status switch
         {
-            Enums.MilestoneStatus.Undefined => CalculateDueStatus(forecastClaimDate),
-            Enums.MilestoneStatus.Draft => CalculateDueStatus(forecastClaimDate),
+            Enums.MilestoneStatus.Undefined => MapDueStatus(dueStatus),
+            Enums.MilestoneStatus.Draft => MapDueStatus(dueStatus),
             Enums.MilestoneStatus.Submitted => MilestoneStatus.Submitted,
             Enums.MilestoneStatus.UnderReview => MilestoneStatus.UnderReview,
             Enums.MilestoneStatus.Approved => MilestoneStatus.Approved,
@@ -28,24 +22,14 @@ public sealed class MilestoneClaimStatusMapper : IMilestoneClaimStatusMapper
         };
     }
 
-    private MilestoneStatus CalculateDueStatus(DateTime forecastClaimDate)
+    private static MilestoneStatus MapDueStatus(MilestoneDueStatus dueStatus)
     {
-        var today = _dateTimeProvider.Now.Date;
-        if (forecastClaimDate.Date.IsAfter(today.AddDays(14)))
+        return dueStatus switch
         {
-            return MilestoneStatus.Undefined;
-        }
-
-        if (forecastClaimDate.Date.IsAfter(today.AddDays(6)))
-        {
-            return MilestoneStatus.DueSoon;
-        }
-
-        if (forecastClaimDate.Date.IsAfter(today.AddDays(-7)))
-        {
-            return MilestoneStatus.Due;
-        }
-
-        return MilestoneStatus.Overdue;
+            MilestoneDueStatus.DueSoon => MilestoneStatus.DueSoon,
+            MilestoneDueStatus.Due => MilestoneStatus.Due,
+            MilestoneDueStatus.Overdue => MilestoneStatus.Overdue,
+            _ => MilestoneStatus.Undefined,
+        };
     }
 }

--- a/src/HE.Investments.AHP.Allocation.Domain/Claims/ValueObjects/MilestoneClaim.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Claims/ValueObjects/MilestoneClaim.cs
@@ -1,5 +1,8 @@
 using HE.Investments.AHP.Allocation.Contract.Claims.Enum;
+using HE.Investments.AHP.Allocation.Domain.Claims.Enums;
 using HE.Investments.Common.Domain;
+using HE.Investments.Common.Extensions;
+using HE.Investments.Common.Utils;
 using MilestoneStatus = HE.Investments.AHP.Allocation.Domain.Claims.Enums.MilestoneStatus;
 
 namespace HE.Investments.AHP.Allocation.Domain.Claims.ValueObjects;
@@ -33,6 +36,27 @@ public class MilestoneClaim : ValueObject
     public bool? CostIncurred { get; }
 
     public bool? IsConfirmed { get; }
+
+    public MilestoneDueStatus CalculateDueStatus(IDateTimeProvider dateTimeProvider)
+    {
+        var today = dateTimeProvider.Now.Date;
+        if (ClaimDate.ForecastClaimDate.Date.IsAfter(today.AddDays(14)))
+        {
+            return MilestoneDueStatus.Undefined;
+        }
+
+        if (ClaimDate.ForecastClaimDate.Date.IsAfter(today.AddDays(6)))
+        {
+            return MilestoneDueStatus.DueSoon;
+        }
+
+        if (ClaimDate.ForecastClaimDate.Date.IsAfter(today.AddDays(-7)))
+        {
+            return MilestoneDueStatus.Due;
+        }
+
+        return MilestoneDueStatus.Overdue;
+    }
 
     protected override IEnumerable<object?> GetAtomicValues()
     {

--- a/src/HE.Investments.AHP.Allocation.Domain/Config/DomainModule.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Config/DomainModule.cs
@@ -25,6 +25,6 @@ public static class DomainModule
         services.AddScoped<IPhaseCrmMapper, PhaseCrmMapper>();
         services.AddScoped<IAllocationBasicInfoMapper, AllocationBasicInfoMapper>();
         services.AddScoped<IClaimsContractMapper, ClaimsContractMapper>();
-        services.AddScoped<IMilestoneClaimStatusMapper, MilestoneClaimStatusMapper>();
+        services.AddSingleton<IMilestoneClaimStatusMapper, MilestoneClaimStatusMapper>();
     }
 }

--- a/src/HE.Investments.AHP.Allocation.Domain/Config/DomainModule.cs
+++ b/src/HE.Investments.AHP.Allocation.Domain/Config/DomainModule.cs
@@ -16,8 +16,15 @@ public static class DomainModule
         services.Decorate<IAllocationCrmContext, RequestCacheAllocationCrmContextDecorator>();
         services.AddScoped<IAllocationRepository, AllocationRepository>();
         services.AddScoped<IPhaseRepository, PhaseRepository>();
+
+        services.AddMappers();
+    }
+
+    private static void AddMappers(this IServiceCollection services)
+    {
         services.AddScoped<IPhaseCrmMapper, PhaseCrmMapper>();
         services.AddScoped<IAllocationBasicInfoMapper, AllocationBasicInfoMapper>();
         services.AddScoped<IClaimsContractMapper, ClaimsContractMapper>();
+        services.AddScoped<IMilestoneClaimStatusMapper, MilestoneClaimStatusMapper>();
     }
 }


### PR DESCRIPTION
### 🛠 Changes being made

Calculate Due Claim status based on forecast claim date based on following requirements
- (nothing - no status) - More than 14 days before Claim Forecast date
- Due soon - Between 14 and 7 days before Claim Forecast date
- Due - Between 6 days before and 6 days after Claim Forecast date
- Overdue - More than 6 days after Claim Forecast date

### 📸 Screenshots (optional)

Today is 11th July 2024
<img alt="image" src="https://github.com/homesengland/he-ssp/assets/24436849/376c07dc-4cfe-4be1-86d7-afab63043a37">


### 🏎 Quality check

- [x] Have you performed local tests?
- [x] Are integration tests passing locally?
- [x] Have you added some unit tests?
